### PR TITLE
rebase: prevent building go-ceph/snapshot_octopus.go (downstream only)

### DIFF
--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
@@ -1,5 +1,6 @@
 // +build !nautilus
-
+// These snapshot APIs are not available in the RHCS build used by OCS.
+// +build rhcs_next
 package rbd
 
 // #cgo LDFLAGS: -lrbd


### PR DESCRIPTION
As the few snapshot mirroring api's are not available in downstream ceph image. Adding the unmet Build Constraint `rhcs_next` to this file from building.


Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

