### PR TITLE
rebase: add newline after build go-ceph/snapshot_octopus.go (downstream only)

### DIFF
--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
@@ -1,6 +1,7 @@
 // +build !nautilus
 // These snapshot APIs are not available in the RHCS build used by OCS.
 // +build rhcs_next
+
 package rbd
 
 // #cgo LDFLAGS: -lrbd


### PR DESCRIPTION
adding newline is required between build tag and the package name. This commit adds the same to fix the build.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

