### PR TITLE
downstream-only: add OWNERS and redhat/ directory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
@@ -1,0 +1,14 @@
+**You must EDIT ME! The contents below is an example only.**
+
+Bug 000000 gets hit when the system is out for its birthday party. After
+providing the system with sufficient cake, it returns to normal business the
+next day.
+
+I hereby confirm that:
+
+- [ ] this change is in the upstream project (*reference?*)
+- [ ] this change is in the devel branch of this project
+- [ ] branches for higher versions of the project have this change merged
+- [ ] this PR is not *downstream-only*, if that was the case, I would have
+  explained its need very clearly
+

--- a/.github/PULL_REQUEST_TEMPLATE/redhat-downstream-only.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-downstream-only.md
@@ -1,0 +1,5 @@
+**You must EDIT ME! The contents below is an example only.**
+
+The downstream CI testing depends on additional settings in the Search
+Optimization so that the project contributors can get a piece of chocolate for
+every merged PR.

--- a/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
@@ -1,0 +1,9 @@
+**You must EDIT ME! The contents below is an example only.**
+
+Sync the upstream changes from `ceph/ceph-csi:devel` into the `devel` branch.
+The most important recent changes that we want included are:
+
+- the new foz bar baz works flawlessly
+- this addresses a bug where users are facing issues with XYZ
+- ...
+

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - ceph-csi-team
+
+reviewers:
+  - ceph-csi-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,9 @@
+aliases:
+  ceph-csi-team:
+    - agarwal-mudit
+    - humblec
+    - madhu-1
+    - nixpanic
+    - rakshith-r
+    - yati1998
+    - yuggupta27

--- a/redhat/Containerfile
+++ b/redhat/Containerfile
@@ -1,0 +1,43 @@
+# This Containerfile is used by openshift-ci to build the image, and push it to
+# quay.io/ocs-dev/ceph-csi
+#
+# This image is based on the latest stable Ceph version, which uses CentOS.
+#
+# Note that other tests run on the latest Fedora release. That makes the binary
+# that gets build not necessary compatible with the Ceph version on other
+# distributions. Hence the need to rebuild the executable on the OS that will
+# be used as deployment image.
+#
+# Ideally we use a base container that is very closely like the Red Hat Ceph
+# Storage (RHCS) product. Unfortunately those container images are not publicly
+# available, so we will use the latest Ceph version that is available. If we
+# settle on a particular Ceph version, we might be missing out on backports
+# that the RHCS product contains (and compiling might fail).
+
+FROM docker.io/ceph/daemon-base:latest AS builder
+
+ENV GOPATH=/go
+
+# install dependencies
+RUN dnf -y install \
+        git \
+        golang \
+        make \
+        librados-devel \
+        librbd-devel \
+    && dnf -y update \
+    && dnf clean all \
+    && true
+
+# compile and link the executable
+COPY . /go/src/github.com/ceph/ceph-csi
+RUN cd /go/src/github.com/ceph/ceph-csi && make
+
+# final container to use in deployments
+FROM docker.io/ceph/daemon-base:latest
+
+COPY --from=builder /go/src/github.com/ceph/ceph-csi/_output/cephcsi /usr/local/bin/cephcsi
+
+RUN chmod +x /usr/local/bin/cephcsi
+
+ENTRYPOINT ["/usr/local/bin/cephcsi"]

--- a/redhat/README.md
+++ b/redhat/README.md
@@ -1,0 +1,105 @@
+# Ceph-CSI Stream
+
+Ceph-CSI Stream is the Red Hat downstream project that contains the pre-release
+state of Ceph-CSI as used in the OpenShift Data Foundation product.
+
+## Git Repository
+
+### Branches
+
+This GitHub repository contains branches for different product versions.
+
+## Backports
+
+All changes in this repository are *backports* from the [upstream
+project][upstream-ceph-csi]. There should be no functional changes (only
+process/CI/building/..) in this repository compared to the upstream project.
+Fixes for any of the release branches should first land in the devel branch
+before they may be backported to the release branch. A backport for the oldest
+release should also be backported to all the newer releases in order to prevent
+re-introducing a bug when a user updates.
+
+### Sync `devel` with upstream `ceph/ceph-csi:devel`
+
+Syncing branches (including the `devel` branch) from upstream should be done
+with a Pull-Request. To create a PR that syncs the latest changes from
+`ceph/ceph-csi:devel` into the `devel branch`, [click here][sync-pr].
+
+### Backporting changes from the `devel` to `release-*` branches
+
+Once a PR has been merged in the devel branch that fixes an issue, a new PR
+with the backport can be created. The easiest way is to use a command like
+
+```
+/cherry-pick release-4.9
+```
+
+The **openshift-cherrypick-robot** will automatically create a new PR for the
+selected branch.
+
+### Pull Requests
+
+Once the product planning enters feature freeze, only backports with related
+Bugzilla references will be allowed to get merged.
+
+To assist developers, there are several Pull Request templates available. It is
+recommended to use these links when creating a new Pull Request:
+
+- [backport][backport-pr]: `?template=redhat-backport.md`
+- [downstream-only][ds-only-pr]: `?template=redhat-downstream-only.md`
+- [sync][sync-pr]: or add `?template=redhat-sync.md`
+
+The `?template=...` appendix can be used when creating the Pull Requests
+through other means than the links above. By appending the `?template=...`
+keyword to the Pull Request URL, the template gets included automatically.
+
+### Downstream-Only Changes
+
+For working with the downstream tools, like OpenShift CI, there are a few
+changes required that are not suitable for the upstream Ceph-CSI project.
+
+1. `OWNERS` file: added with maintainers for reviewing and approving PRs
+1. `OWNERS_ALIASES` file: members of the Ceph-CSI team
+1. `redhat/` directory: additional files (like this `README.md`)
+1. `redhat/Containerfile`: used to build the quay.io/ocs-dev/ceph-csi image
+1. `.github/PULL_REQUEST_TEMPLATE/redhat-*`: guidance for creating PRs
+
+## Continuous Integration
+
+OpenShift CI (Prow) is used for testing the changes that land in this GitHub
+repository. The configuration of the jobs can be found in the [OpenShift
+Release repository][ocp-release].
+
+### Container Images
+
+Images that have been built from a PR that was merged will get automatically
+pushed into [the Qoay.io registry][quay-ceph-csi]. The configuration for the
+mirroring job is part of the [OpenShift Release
+repository][ocp-release-mirror].
+
+When a new release is planned, the mirroring will need to have the new branch
+and tags listed as well.
+
+Consumption of these images does not require any permissions, the images can be
+pulled with podman like:
+
+```
+podman pull quay.io/ocs-dev/ceph-csi:latest
+```
+
+### Bugzilla Plugin
+
+PRs that need a Bugzilla reference are handled by the Bugzilla Plugin which
+runs as part of Prow. The configuration gates the requirement on BZs to be
+linked, before the tests will pass and the PR can be merged. Once a branch is
+added to the GitHub repository, [the configuration][bz-config] needs adaption
+for the new branch as well.
+
+[upstream-ceph-csi]: https://github.com/ceph/ceph-csi
+[sync-pr]: https://github.com/red-hat-storage/ceph-csi/compare/devel...ceph:devel?template=redhat-sync.md
+[backport-pr]: https://github.com/red-hat-storage/ceph-csi/compare/release-4.9...devel?template=redhat-backport.md
+[ds-only-pr]: https://github.com/red-hat-storage/ceph-csi/compare/devel...ceph:devel?template=redhat-downstream-only.md
+[ocp-release]: https://github.com/openshift/release/tree/master/ci-operator/config/red-hat-storage/ceph-csi
+[ocp-release-mirror]: https://github.com/openshift/release/tree/master/core-services/image-mirroring/ceph-csi
+[quay-ceph-csi]: https://quay.io/repository/ocs-dev/ceph-csi?tab=tags
+[bz-config]: https://github.com/openshift/release/blob/master/core-services/prow/02_config/red-hat-storage/ceph-csi/_pluginconfig.yaml


### PR DESCRIPTION
These OWNERS files are needed for the openshift-ci bot to allow members
of the Ceph-CSI team to approve PRs and merge them automatically.

The redhat/ directory contains a README.md with details about the
downstream procedures. A Container file has been added as well, which
will allow running builds on the OpenShift CI for the PRs that are
created.
