### PR TITLE
Bug 1997624: [KMS] PV encryption fails when using vault namespace functionality in ODF 4.9

### DIFF
--- a/internal/kms/vault.go
+++ b/internal/kms/vault.go
@@ -192,10 +192,15 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err
 	}
-	vaultAuthNamespace := vaultNamespace // optional, same as vaultNamespace
+	vaultAuthNamespace := ""
 	err = setConfigString(&vaultAuthNamespace, config, "vaultAuthNamespace")
 	if errors.Is(err, errConfigOptionInvalid) {
 		return err
+	}
+	// if the vaultAuthNamespace key is present and value is empty in config, set
+	// the optional vaultNamespace.
+	if vaultAuthNamespace == "" {
+		vaultAuthNamespace = vaultNamespace
 	}
 	// set the option if the value was not invalid
 	if firstInit || !errors.Is(err, errConfigOptionMissing) {


### PR DESCRIPTION
When we read the csi-kms-connection-details configmap
vaultAuthNamespace might not be set when we do the
conversion the vaultAuthNamespace might be set to empty
key and this commits check for the empty value of
vaultAuthNamespace and set the vaultAuthNamespace
to vaultNamespace.

setting empty value for vaultAuthNamespace happened due
to Marshalling at https://github.com/ceph/ceph-csi/blob/devel/
internal/kms/vault_tokens.go#L136-L139.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 8c8f34cf7a98527ef6fb9324f1da7b0cf50a3445)
