### PR TITLE
Bug 1975730: Using two different backend paths for the encrypted parent and the restored PVC should succeed

### DIFF
--- a/internal/rbd/clone.go
+++ b/internal/rbd/clone.go
@@ -161,7 +161,7 @@ func (rv *rbdVolume) createCloneFromImage(ctx context.Context, parentVol *rbdVol
 	}
 
 	if parentVol.isEncrypted() {
-		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
+		err = parentVol.copyEncryptionConfig(&rv.rbdImage, false)
 		if err != nil {
 			return fmt.Errorf("failed to copy encryption config for %q: %w", rv, err)
 		}

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1092,7 +1092,7 @@ func cloneFromSnapshot(
 	defer vol.Destroy()
 
 	if rbdVol.isEncrypted() {
-		err = rbdVol.copyEncryptionConfig(&vol.rbdImage)
+		err = rbdVol.copyEncryptionConfig(&vol.rbdImage, false)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -1211,7 +1211,7 @@ func (cs *ControllerServer) doSnapshotClone(
 	}()
 
 	if parentVol.isEncrypted() {
-		cryptErr := parentVol.copyEncryptionConfig(&cloneRbd.rbdImage)
+		cryptErr := parentVol.copyEncryptionConfig(&cloneRbd.rbdImage, false)
 		if cryptErr != nil {
 			log.WarningLog(ctx, "failed copy encryption "+
 				"config for %q: %v", cloneRbd, cryptErr)

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -334,7 +334,7 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	}
 
 	if parentVol != nil && parentVol.isEncrypted() {
-		err = parentVol.copyEncryptionConfig(&rv.rbdImage)
+		err = parentVol.copyEncryptionConfig(&rv.rbdImage, false)
 		if err != nil {
 			log.ErrorLog(ctx, err.Error())
 

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1373,7 +1373,7 @@ func (rv *rbdVolume) cloneRbdImageFromSnapshot(
 	if pSnapOpts.isEncrypted() {
 		pSnapOpts.conn = rv.conn.Copy()
 
-		err = pSnapOpts.copyEncryptionConfig(&rv.rbdImage)
+		err = pSnapOpts.copyEncryptionConfig(&rv.rbdImage, true)
 		if err != nil {
 			return fmt.Errorf("failed to clone encryption config: %w", err)
 		}


### PR DESCRIPTION
During PVC snapshot/clone both kms config and passphrase needs to copied,
while for PVC restore only passphrase needs to be copied to dest rbdvol
since destination storageclass may have another kms config.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 59b7a261754d8b4af4fbf63e2794bca08329c421)

/cc @agarwal-mudit @nixpanic @Madhu-1 