### PR TITLE
BUG 2017392: check local image state for resyncing

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -532,7 +532,6 @@ func checkRemoteSiteStatus(ctx context.Context, mirrorStatus *librbd.GlobalMirro
 // ResyncVolume extracts the RBD volume information from the volumeID, If the
 // image is present, mirroring is enabled and the image is in demoted state.
 // If yes it will resync the image to correct the split-brain.
-// FIXME: reduce complexity.
 func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	req *replication.ResyncVolumeRequest,
 ) (*replication.ResyncVolumeResponse, error) {

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -513,9 +513,10 @@ func checkRemoteSiteStatus(ctx context.Context, mirrorStatus *librbd.GlobalMirro
 	for _, s := range mirrorStatus.SiteStatuses {
 		log.UsefulLog(
 			ctx,
-			"peer site mirrorUUID=%s, mirroring state=%s, description=%s and lastUpdate=%s",
+			"peer site mirrorUUID=%q, daemon up=%t, mirroring state=%q, description=%q and lastUpdate=%d",
 			s.MirrorUUID,
-			s.State.String(),
+			s.Up,
+			s.State,
 			s.Description,
 			s.LastUpdate)
 		if s.MirrorUUID != "" {
@@ -611,8 +612,9 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	lastUpdateTime := time.Unix(localStatus.LastUpdate, 0).UTC()
 	log.UsefulLog(
 		ctx,
-		"local image mirroring state=%s, description=%s and lastUpdate=%s",
-		localStatus.State.String(),
+		"local status: daemon up=%t, image mirroring state=%q, description=%q and lastUpdate=%s",
+		localStatus.Up,
+		localStatus.State,
 		localStatus.Description,
 		lastUpdateTime)
 

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -523,16 +523,15 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 func checkRemoteSiteStatus(ctx context.Context, mirrorStatus *librbd.GlobalMirrorImageStatus) bool {
 	ready := true
 	for _, s := range mirrorStatus.SiteStatuses {
+		log.UsefulLog(
+			ctx,
+			"peer site mirrorUUID=%s, mirroring state=%s, description=%s and lastUpdate=%s",
+			s.MirrorUUID,
+			s.State.String(),
+			s.Description,
+			s.LastUpdate)
 		if s.MirrorUUID != "" {
 			if imageMirroringState(s.State.String()) != unknown && !s.Up {
-				log.UsefulLog(
-					ctx,
-					"peer site mirrorUUID=%s, mirroring state=%s, description=%s and lastUpdate=%s",
-					s.MirrorUUID,
-					s.State.String(),
-					s.Description,
-					s.LastUpdate)
-
 				ready = false
 			}
 		}


### PR DESCRIPTION
below are the local states of the mirrored image

"unknown" -> If the image is in an error state means data is completely synced
"error" -> If the image is in an error state means it needs resync
"syncing"
"starting_replay"
"replaying" -> If the image is in a replaying state means its replaying from primary source
"stopping_replay"
"stopped"
If the resync is successfully started which means the image will be in a "replaying" state we can consider "replaying" state to report resync successfully going on the state.
we are discarding the intermediate states like "syncing", "starting_replay" and "stopping_replay".

This addresses comment #2572 (review)

Note to review: This is the suggestion approved by the RBD team. https://bugzilla.redhat.com/show_bug.cgi?id=2012143#c17

backport of https://github.com/ceph/ceph-csi/pull/2594

depends on #39 