### PR TITLE
BUG 2030742: rbd: reset dummy image id

### DIFF
--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -297,6 +297,9 @@ func createDummyImage(ctx context.Context, rbdVol *rbdVolume) error {
 		}
 		dummyVol := *rbdVol
 		dummyVol.RbdImageName = imgName
+		// dummyVol holds rbdVol details, reset ImageID or else dummy image cannot be
+		// deleted from trash during repair operation.
+		dummyVol.ImageID = ""
 		f := []string{
 			librbd.FeatureNameLayering,
 			librbd.FeatureNameObjectMap,


### PR DESCRIPTION
dummy image rbdVolume struct is derived from the actual one rbdVolume of the volumeID sent in the EnableVolumeReplication request. and the dummy rbdVolume struct contains the image id of the actual volume because
of that when we are repairing the dummy image the image is sent to trash but not deleted due to the wrong image ID. resetting
the image id will makes sure the image id is fetching from ceph cluster and same image id will be used for manager operation.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 810e285c5043692348b4e9357958726483ff6800)

backport of https://github.com/ceph/ceph-csi/pull/2733

Note:- should get  merged after https://github.com/red-hat-storage/ceph-csi/pull/60