### PR TITLE
BUG 2052027:  fix omap deletion in DeleteSnapshot

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -779,10 +779,10 @@ func (cs *ControllerServer) DeleteSnapshot(
 			// success as deletion is complete
 			return &csi.DeleteSnapshotResponse{}, nil
 		case errors.Is(err, cerrors.ErrSnapNotFound):
-			err = core.UndoSnapReservation(ctx, volOpt, *sid, sid.FsSnapshotName, cr)
+			err = core.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
 			if err != nil {
 				log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
-					sid.FsSubvolName, sid.FsSnapshotName, err)
+					sid.RequestName, sid.FsSnapshotName, err)
 
 				return nil, status.Error(codes.Internal, err.Error())
 			}
@@ -792,10 +792,10 @@ func (cs *ControllerServer) DeleteSnapshot(
 			// if the error is ErrVolumeNotFound, the subvolume is already deleted
 			// from backend, Hence undo the omap entries and return success
 			log.ErrorLog(ctx, "Volume not present")
-			err = core.UndoSnapReservation(ctx, volOpt, *sid, sid.FsSnapshotName, cr)
+			err = core.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
 			if err != nil {
 				log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
-					sid.FsSubvolName, sid.FsSnapshotName, err)
+					sid.RequestName, sid.FsSnapshotName, err)
 
 				return nil, status.Error(codes.Internal, err.Error())
 			}
@@ -829,7 +829,7 @@ func (cs *ControllerServer) DeleteSnapshot(
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	err = core.UndoSnapReservation(ctx, volOpt, *sid, sid.FsSnapshotName, cr)
+	err = core.UndoSnapReservation(ctx, volOpt, *sid, sid.RequestName, cr)
 	if err != nil {
 		log.ErrorLog(ctx, "failed to remove reservation for snapname (%s) with backing snap (%s) (%s)",
 			sid.RequestName, sid.FsSnapshotName, err)


### PR DESCRIPTION
the omap is stored with the requested snapshot name not with the subvolume snapshotname. This fix uses the correct snapshot request name to cleanup the omap once the subvolume snapshot is deleted.

fixes: #2832

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 294355590422f280953991d6a55553ce1a3db15c)

