### PR TITLE
Sync rhs/ceph:devel with ceph/ceph:devel

### DIFF
--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -127,11 +127,11 @@ func (rsns *ReclaimSpaceNodeServer) NodeReclaimSpace(
 		return nil, status.Error(codes.Unimplemented, "multi-node space reclaim is not supported")
 	}
 
-	cmd := "fstrim"
 	if isBlock {
-		cmd = "blkdiscard"
+		return nil, status.Error(codes.Unimplemented, "block-mode space reclaim is not supported")
 	}
 
+	cmd := "fstrim"
 	_, stderr, err := util.ExecCommand(ctx, cmd, path)
 	if err != nil {
 		return nil, status.Errorf(


### PR DESCRIPTION
blkdiscard cmd discards all data on the block device which
is not desired. Hence, return unimplemented code if the
volume access mode is block.

Signed-off-by: Rakshith R <rar@redhat.com>

/cc @agarwal-mudit @Madhu-1 @humblec @red-hat-storage/ceph-csi-admins 