### PR TITLE
Bug 2094856: rbd: create token and use it for vault SA

### DIFF
--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -31,4 +31,7 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
 {{- end -}}

--- a/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-clusterrole.yaml
@@ -70,5 +70,8 @@ rules:
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
 {{- end }}
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
 
 {{- end -}}

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -30,6 +30,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
@@ -63,6 +63,9 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/util/k8s/version.go
+++ b/internal/util/k8s/version.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetServerVersion returns kubernetes server major and minor version as
+// integer.
+func GetServerVersion(client *kubernetes.Clientset) (int, int, error) {
+	version, err := client.ServerVersion()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get ServerVersion: %w", err)
+	}
+
+	major, err := strconv.Atoi(version.Major)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to convert Kubernetes major version %q to int: %w", version.Major, err)
+	}
+
+	minor, err := strconv.Atoi(version.Minor)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to convert Kubernetes minor version %q to int: %w", version.Minor, err)
+	}
+
+	return major, minor, nil
+}


### PR DESCRIPTION
create the token if kubernetes version in 1.24+ and use it for vault sa.

I hereby confirm that:

- [x] this change is in the upstream project (ceph/ceph-csi#3174)
- [x] this change is in the devel branch of this project (commit 7a2dd4c3cf5891fc3d7627843b124dcdf4f8abf9)
- [x] branches for higher versions of the project have this change merged
- [x] this PR is not *downstream-only*, if that was the case, I would have
  explained its need very clearly

