### PR TITLE
[DOWNSTREAM ONLY] ci: disable dependabot PR creation for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
       - dependency-name: "k8s.io/pod-security-admission"
       - dependency-name: "k8s.io/sample-apiserver"
   - package-ecosystem: "gomod"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/actions/retest"
     schedule:
       interval: "weekly"
@@ -50,6 +52,8 @@ updates:
     commit-message:
       prefix: "rebase"
   - package-ecosystem: "github-actions"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
Dependabot does not need to report available updates for vendored
dependencies in the downstream repository. Updates to dependencies are
synced from the upstream repository when needed. There is also the
"Upstream First" requirement, which we follow closely.