### PR TITLE
[DOWNSTREAM-ONLY]rbd: use VaultTenantSA instead of vaultTenantSA

### DIFF
--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -341,7 +341,7 @@ func (kms *VaultTenantSA) getTokenPath() (string, error) {
 // automatically created. Hence, use the create token api to fetch it.
 // refer: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md \
 // #no-really-you-must-read-this-before-you-upgrade-1 .
-func (kms *vaultTenantSA) createToken(sa *corev1.ServiceAccount, client *kubernetes.Clientset) (string, error) {
+func (kms *VaultTenantSA) createToken(sa *corev1.ServiceAccount, client *kubernetes.Clientset) (string, error) {
 	major, minor, err := k8s.GetServerVersion(client)
 	if err != nil {
 		return "", fmt.Errorf("failed to get server version: %w", err)


### PR DESCRIPTION
This struct has been unexported in recent commits and
is exported in release 4.10 branch which causes build to
fail. This commit changes it back to exported variant
`VaultTenantSA`.

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
