### PR TITLE
[DOWNSTEAM-ONLY] Bug 2098562: fix build failure related to VaultTenantSA.createToken

### DIFF
--- a/internal/kms/vault_sa.go
+++ b/internal/kms/vault_sa.go
@@ -341,7 +341,7 @@ func (kms *VaultTenantSA) getTokenPath() (string, error) {
 // automatically created. Hence, use the create token api to fetch it.
 // refer: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md \
 // #no-really-you-must-read-this-before-you-upgrade-1 .
-func (kms *vaultTenantSA) createToken(sa *corev1.ServiceAccount, client *kubernetes.Clientset) (string, error) {
+func (kms *VaultTenantSA) createToken(sa *corev1.ServiceAccount, client *kubernetes.Clientset) (string, error) {
 	major, minor, err := k8s.GetServerVersion(client)
 	if err != nil {
 		return "", fmt.Errorf("failed to get server version: %w", err)


### PR DESCRIPTION
Pull-Request #99 backported a commit that applies cleanly, but causes a
build failure:

    internal/kms/vault_sa.go:313:12: kms.createToken undefined (type *VaultTenantSA has no field or method createToken)
    internal/kms/vault_sa.go:344:12: undefined: vaultTenantSA

In recent versions, `vaultTenantSA` is used, but release-4.10 is stuck
on the old naming of `VaultTenantSA`. The unexporting was done in
upstream ceph/ceph-csi#2750, which includes more changes than what we
want in a backport.
