### PR TITLE
[DOWNSTREAM-ONLY] rbd: prevent failure in NodeGetVolumeStats for partitioned devices

### DIFF
--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1103,7 +1103,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 //
 // TODO: https://github.com/container-storage-interface/spec/issues/371#issuecomment-756834471
 func blockNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.NodeGetVolumeStatsResponse, error) {
-	args := []string{"--noheadings", "--bytes", "--output=SIZE", targetPath}
+	args := []string{"--noheadings", "--nodeps", "--bytes", "--output=SIZE", targetPath}
 	lsblkSize, _, err := util.ExecCommand(ctx, "/bin/lsblk", args...)
 	if err != nil {
 		err = fmt.Errorf("lsblk %v returned an error: %w", args, err)


### PR DESCRIPTION
In case the Block-mode volume has multiple partitions, `lsblk` returns
the size for each partition. Ceph-CSI is not prepared for this, it
expects only a single value. When multiple values are returned, parsing
fails and an error is reported.

`lsblk` has a `--nodeps` option that prevents reporting the size of the
partitions. By adding this option to the commandline, the output is a
single line again, which can be parsed without issues.

Downstream-only note:

Ceph-CSI v3.5 uses a helper function from a Kubernetes package to detect
the size of the block-volume instead of `lsblk`. ODF-4.9 and earlier do
not have this utility function vendored, so that can not be used. The
`--nodeps` option can not be added in the upstream Ceph-CSI project
anymore, because versions calling `lsblk` are not maintained by the
community anymore.
