### PR TITLE
Bug 2099965: rbd: provide option to disable setting metadata on rbd images

### DIFF
--- a/cmd/cephcsi.go
+++ b/cmd/cephcsi.go
@@ -69,6 +69,7 @@ func init() {
 	flag.StringVar(&conf.PluginPath, "pluginpath", defaultPluginPath, "plugin path")
 	flag.StringVar(&conf.StagingPath, "stagingpath", defaultStagingPath, "staging path")
 	flag.StringVar(&conf.ClusterName, "clustername", "", "name of the cluster")
+	flag.BoolVar(&conf.SetMetadata, "setmetadata", false, "set metadata on the volume")
 	flag.StringVar(&conf.InstanceID, "instanceid", "", "Unique ID distinguishing this instance of Ceph CSI among other"+
 		" instances, when sharing Ceph clusters across CSI instances for provisioning")
 	flag.IntVar(&conf.PidLimit, "pidlimit", 0, "the PID limit to configure through cgroups")
@@ -251,6 +252,7 @@ func main() {
 			DriverName:  dname,
 			Namespace:   conf.DriverNamespace,
 			ClusterName: conf.ClusterName,
+			SetMetadata: conf.SetMetadata,
 		}
 		// initialize all controllers before starting.
 		initControllers()

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -38,6 +38,7 @@ type Config struct {
 	DriverName  string
 	Namespace   string
 	ClusterName string
+	SetMetadata bool
 }
 
 // ControllerList holds the list of managers need to be started.

--- a/internal/controller/persistentvolume/persistentvolume.go
+++ b/internal/controller/persistentvolume/persistentvolume.go
@@ -184,6 +184,7 @@ func (r *ReconcilePersistentVolume) reconcilePV(ctx context.Context, obj runtime
 		requestName,
 		pvcNamespace,
 		r.config.ClusterName,
+		r.config.SetMetadata,
 		cr)
 	if err != nil {
 		log.ErrorLogMsg("failed to regenerate journal %s", err)

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -53,6 +53,9 @@ type ControllerServer struct {
 
 	// Cluster name
 	ClusterName string
+
+	// Set metadata on volume
+	SetMetadata bool
 }
 
 func (cs *ControllerServer) validateVolumeReq(ctx context.Context, req *csi.CreateVolumeRequest) error {
@@ -133,7 +136,10 @@ func (cs *ControllerServer) parseVolCreateRequest(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// set cluster name on volume
 	rbdVol.ClusterName = cs.ClusterName
+	// set metadata on volume
+	rbdVol.EnableMetadata = cs.SetMetadata
 
 	// if the KMS is of type VaultToken, additional metadata is needed
 	// depending on the tenant, the KMS can be configured with other
@@ -998,6 +1004,7 @@ func (cs *ControllerServer) CreateSnapshot(
 
 		return nil, err
 	}
+	rbdVol.EnableMetadata = cs.SetMetadata
 
 	// Check if source volume was created with required image features for snaps
 	if !rbdVol.hasSnapshotFeature() {

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -160,6 +160,7 @@ func (r *Driver) Run(conf *util.Config) {
 	if conf.IsControllerServer {
 		r.cs = NewControllerServer(r.cd)
 		r.cs.ClusterName = conf.ClusterName
+		r.cs.SetMetadata = conf.SetMetadata
 		r.rs = NewReplicationServer(r.cs)
 	}
 	if !conf.IsControllerServer && !conf.IsNodeServer {

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -542,6 +542,7 @@ func RegenerateJournal(
 	requestName,
 	clusterName string,
 	owner string,
+	setMetadata bool,
 	cr *util.Credentials,
 ) (string, error) {
 	ctx := context.Background()
@@ -556,6 +557,7 @@ func RegenerateJournal(
 	rbdVol = &rbdVolume{}
 	rbdVol.VolID = volumeID
 	rbdVol.ClusterName = clusterName
+	rbdVol.EnableMetadata = setMetadata
 
 	err = vi.DecomposeCSIID(rbdVol.VolID)
 	if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -118,6 +118,7 @@ type rbdImage struct {
 	ParentPool string
 	// Cluster name
 	ClusterName string
+
 	// Owner is the creator (tenant, Kubernetes Namespace) of the volume
 	Owner string
 
@@ -1933,6 +1934,10 @@ func genVolFromVolIDWithMigration(
 
 // setVolumeMetadata set PV/PVC/PVCNamespace metadata on RBD image.
 func (rv *rbdVolume) setVolumeMetadata(parameters map[string]string) error {
+        if !rv.EnableMetadata {
+                return nil
+        }
+
 	for k, v := range k8s.GetVolumeMetadata(parameters) {
 		err := rv.SetMetadata(k, v)
 		if err != nil {
@@ -1954,6 +1959,10 @@ func (rv *rbdVolume) setVolumeMetadata(parameters map[string]string) error {
 // setSnapshotMetadata Set snapshot-name/snapshot-namespace/snapshotcontent-name metadata
 // on RBD image.
 func (rv *rbdVolume) setSnapshotMetadata(parameters map[string]string) error {
+        if !rv.EnableMetadata {
+                return nil
+        }
+
 	for k, v := range k8s.GetSnapshotMetadata(parameters) {
 		err := rv.SetMetadata(k, v)
 		if err != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -101,6 +101,8 @@ type Config struct {
 	// cephfs related flags
 	ForceKernelCephFS bool // force to use the ceph kernel client even if the kernel is < 4.17
 
+	SetMetadata bool // set metadata on the volume
+
 	// RbdHardMaxCloneDepth is the hard limit for maximum number of nested volume clones that are taken before a flatten
 	// occurs
 	RbdHardMaxCloneDepth uint


### PR DESCRIPTION
Bug 2099965 was partially fixed by #108, but upstream commit 78a8aac726eb71c35d94c2fe83525af3c58b6965 was not included in that PR.

I hereby confirm that:

- [x] this change is in the upstream project (ceph/ceph-csi#3016)
- [x] this change is in the devel branch of this project (commit caf409065751b16cea98ff99fba39caeb70cc589)
- [x] branches for higher versions of the project have this change merged
- [x] this PR is not *downstream-only*, if that was the case, I would have
  explained its need very clearly

This commit did not apply cleanly, so careful review is needed.