### PR TITLE
BUG 2120927: cephfs: remove extra check for restore size

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -165,14 +165,6 @@ func checkValidCreateVolumeRequest(
 				parentVol.Size,
 				vol.Size)
 		}
-	case sID != nil:
-		if vol.Size < parentVol.Size {
-			return fmt.Errorf(
-				"cannot restore from snapshot %s: volume size %d is smaller than source volume size %d",
-				sID.SnapshotID,
-				parentVol.Size,
-				vol.Size)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Looks like cephfs snapshot size is buggy and its getting removed in ceph fs. we cannot get the size of the snapshot during CreateVolume call, so we cannot do any size check at CreateVolume to check if the restore size is smaller or not.

As we are removing this check it also fixes #3147 but we dont have any validation at CSI level for smaller restore we need to depend on kubernetes external-provisioner for it.

fixes: #3147

This is required for BZ https://bugzilla.redhat.com/show_bug.cgi?id=2120927

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 7da7edb08c382bdf22d83f9942c718af62c5fbea)


/hold 
Note:- should be merged tomorrow