### PR TITLE
Bug 2132270: util: make inode metrics optional in FilesystemNodeGetVolumeStats()

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -637,7 +637,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, false)
 	}
 
 	return nil, status.Errorf(codes.InvalidArgument, "targetpath %q is not a directory or device", targetPath)

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -88,7 +88,7 @@ func TestFilesystemNodeGetVolumeStats(t *testing.T) {
 
 	// retry until a mountpoint is found
 	for {
-		stats, err := FilesystemNodeGetVolumeStats(context.TODO(), mount.New(""), cwd)
+		stats, err := FilesystemNodeGetVolumeStats(context.TODO(), mount.New(""), cwd, true)
 		if err != nil && cwd != "/" && strings.HasSuffix(err.Error(), "is not mounted") {
 			// try again with the parent directory
 			cwd = filepath.Dir(cwd)

--- a/internal/nfs/nodeserver/nodeserver.go
+++ b/internal/nfs/nodeserver/nodeserver.go
@@ -182,7 +182,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, false)
 	}
 
 	return nil, status.Errorf(codes.InvalidArgument,

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1240,7 +1240,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, ns.Mounter, targetPath, true)
 	} else if (stat.Mode() & os.ModeDevice) == os.ModeDevice {
 		return blockNodeGetVolumeStats(ctx, targetPath)
 	}


### PR DESCRIPTION
CephFS does not have a concept of "free inodes", inodes get allocated on-demand in the filesystem.

This confuses alerting managers that expect a (high) number of free inodes, and warnings get produced if the number of free inodes is not high enough. This causes alerts to always get reported for CephFS.

To prevent the false-positive alerts from happening, the NodeGetVolumeStats procedure for CephFS (and CephNFS) will not contain inodes in the reply anymore.

I hereby confirm that:

- [x] this change is in the upstream project (https://github.com/ceph/ceph-csi/pull/3407)
- [x] this change is in the devel branch of this project (#138)
- [ ] branches for higher versions of the project have this change merged
- [ ] this PR is not *downstream-only*, if that was the case, I would have
  explained its need very clearly

