### PR TITLE
BUG 2139323: return error if last sync time not present 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ceph/go-ceph v0.17.0
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/csi-addons/replication-lib-utils v0.2.0
-	github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900
+	github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8
 	github.com/gemalto/kmip-go v0.0.8-0.20220721195433-3fe83e2d3f26
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/csi-addons/replication-lib-utils v0.2.0 h1:tGs42wfjkObbBo/98a3uxTFWEJ1dq5PIMqPWtdLd040=
 github.com/csi-addons/replication-lib-utils v0.2.0/go.mod h1:ROQlEsc2EerVtc/K/C+6Hx8pqaQ9MVy9xFFpyKfI9lc=
 github.com/csi-addons/spec v0.1.0/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
-github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900 h1:zX0138DipZsZqxK1UwAmaRZmL89OuQMkwh7FtvTDgFw=
-github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
+github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8 h1:fYkq+S2FCMM/yl2BjjSNpAZjKuyPCwtkV6F155u1jiE=
+github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/dst v0.26.2/go.mod h1:UMDJuIRPfyUCC78eFuB+SV/WI8oDeyFDvM/JR6NI3IU=
 github.com/dave/gopackages v0.0.0-20170318123100-46e7023ec56e/go.mod h1:i00+b/gKdIDIxuLDFob7ustLAVqhsZRk2qVZrArELGQ=

--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -42,4 +42,7 @@ var (
 	ErrMissingImageNameInVolID = errors.New("rbd image name information can not be empty in volID")
 	// ErrDecodeClusterIDFromMonsInVolID is returned when mons hash decoding on migration volID.
 	ErrDecodeClusterIDFromMonsInVolID = errors.New("failed to get clusterID from monitors hash in volID")
+	// ErrLastSyncTimeNotFound is returned when last sync time is not found for
+	// the image.
+	ErrLastSyncTimeNotFound = errors.New("last sync time not found")
 )

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -822,6 +822,12 @@ func getLastSyncTime(description string) (*timestamppb.Timestamp, error) {
 		return nil, fmt.Errorf("failed to unmarshal description: %w", err)
 	}
 
+	// If the json unmarsal is successful but the local snapshot time is 0, we
+	// need to consider it as an error as the LastSyncTime is required.
+	if localSnapTime.LocalSnapshotTime == 0 {
+		return nil, fmt.Errorf("empty local snapshot timestamp: %w", ErrLastSyncTimeNotFound)
+	}
+
 	lastUpdateTime := time.Unix(localSnapTime.LocalSnapshotTime, 0)
 	lastSyncTime := timestamppb.New(lastUpdateTime)
 

--- a/internal/rbd/replicationcontrollerserver.go
+++ b/internal/rbd/replicationcontrollerserver.go
@@ -767,7 +767,12 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	description := remoteStatus.Description
 	lastSyncTime, err := getLastSyncTime(description)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get last sync time: %w", err)
+		if errors.Is(err, ErrLastSyncTimeNotFound) {
+			return nil, status.Errorf(codes.NotFound, "failed to get last sync time: %v", err)
+		}
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Errorf(codes.Internal, "failed to get last sync time: %v", err)
 	}
 
 	resp := &replication.GetVolumeReplicationInfoResponse{
@@ -804,13 +809,14 @@ func getLastSyncTime(description string) (*timestamppb.Timestamp, error) {
 	// description = "replaying,{"bytes_per_second":0.0,
 	// "bytes_per_snapshot":149504.0,"local_snapshot_timestamp":1662655501
 	// ,"remote_snapshot_timestamp":1662655501}"
-	// In case there is no local snapshot timestamp we can pass the default value
+	// In case there is no local snapshot timestamp return an error as the
+	// LastSyncTime is required.
 	if description == "" {
-		return nil, nil
+		return nil, fmt.Errorf("empty description: %w", ErrLastSyncTimeNotFound)
 	}
 	splittedString := strings.SplitN(description, ",", 2)
 	if len(splittedString) == 1 {
-		return nil, nil
+		return nil, fmt.Errorf("no local snapshot timestamp: %w", ErrLastSyncTimeNotFound)
 	}
 	type localStatus struct {
 		LocalSnapshotTime int64 `json:"local_snapshot_timestamp"`

--- a/internal/rbd/replicationcontrollerserver_test.go
+++ b/internal/rbd/replicationcontrollerserver_test.go
@@ -455,7 +455,7 @@ func TestValidateLastSyncTime(t *testing.T) {
 			"empty description",
 			"",
 			nil,
-			"",
+			ErrLastSyncTimeNotFound.Error(),
 		},
 		{
 			"description without local_snapshot_timestamp",
@@ -467,13 +467,13 @@ func TestValidateLastSyncTime(t *testing.T) {
 			"description with invalid JSON",
 			`replaying,{"bytes_per_second":0.0,"bytes_per_snapshot":149504.0","remote_snapshot_timestamp":1662655501`,
 			nil,
-			"failed to unmarshal description",
+			"failed to unmarshal",
 		},
 		{
 			"description with no JSON",
 			`replaying`,
 			nil,
-			"",
+			ErrLastSyncTimeNotFound.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,7 +153,7 @@ github.com/container-storage-interface/spec/lib/go/csi
 # github.com/csi-addons/replication-lib-utils v0.2.0
 ## explicit; go 1.15
 github.com/csi-addons/replication-lib-utils/protosanitizer
-# github.com/csi-addons/spec v0.1.2-0.20220906123848-52ce69f90900
+# github.com/csi-addons/spec v0.1.2-0.20221101132540-98eff76b0ff8
 ## explicit
 github.com/csi-addons/spec/lib/go/fence
 github.com/csi-addons/spec/lib/go/identity


### PR DESCRIPTION
As per the csiaddon spec, last sync time is a required parameter in the GetVolumeReplicationInfo if we are failed to parse the description, we return an error message instead of nil which is an empty response.

Signed-off-by: madhupr007@gmail.com

Backport of https://github.com/ceph/ceph-csi/pull/3489

