### PR TITLE
BUG 2149677: util: make inode metrics optional in FilesystemNodeGetVolumeStats()

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -491,7 +491,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, targetPath, false)
 	}
 
 	return nil, status.Errorf(codes.InvalidArgument, "targetpath %q is not a directory or device", targetPath)

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -225,7 +225,11 @@ func panicHandler(
 // requested by the NodeGetVolumeStats CSI procedure.
 // It is shared for FileMode volumes, both the CephFS and RBD NodeServers call
 // this.
-func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.NodeGetVolumeStatsResponse, error) {
+func FilesystemNodeGetVolumeStats(
+	ctx context.Context,
+	targetPath string,
+	includeInodes bool,
+) (*csi.NodeGetVolumeStatsResponse, error) {
 	isMnt, err := util.IsMountPoint(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -258,23 +262,8 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 	if !ok {
 		log.ErrorLog(ctx, "failed to fetch used bytes")
 	}
-	inodes, ok := (*(volMetrics.Inodes)).AsInt64()
-	if !ok {
-		log.ErrorLog(ctx, "failed to fetch available inodes")
 
-		return nil, status.Error(codes.Unknown, "failed to fetch available inodes")
-	}
-	inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
-	if !ok {
-		log.ErrorLog(ctx, "failed to fetch free inodes")
-	}
-
-	inodesUsed, ok := (*(volMetrics.InodesUsed)).AsInt64()
-	if !ok {
-		log.ErrorLog(ctx, "failed to fetch used inodes")
-	}
-
-	return &csi.NodeGetVolumeStatsResponse{
+	res := &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
 			{
 				Available: requirePositive(available),
@@ -282,14 +271,35 @@ func FilesystemNodeGetVolumeStats(ctx context.Context, targetPath string) (*csi.
 				Used:      requirePositive(used),
 				Unit:      csi.VolumeUsage_BYTES,
 			},
-			{
-				Available: requirePositive(inodesFree),
-				Total:     requirePositive(inodes),
-				Used:      requirePositive(inodesUsed),
-				Unit:      csi.VolumeUsage_INODES,
-			},
 		},
-	}, nil
+	}
+
+	if includeInodes {
+		inodes, ok := (*(volMetrics.Inodes)).AsInt64()
+		if !ok {
+			log.ErrorLog(ctx, "failed to fetch available inodes")
+
+			return nil, status.Error(codes.Unknown, "failed to fetch available inodes")
+		}
+		inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
+		if !ok {
+			log.ErrorLog(ctx, "failed to fetch free inodes")
+		}
+
+		inodesUsed, ok := (*(volMetrics.InodesUsed)).AsInt64()
+		if !ok {
+			log.ErrorLog(ctx, "failed to fetch used inodes")
+		}
+
+		res.Usage = append(res.Usage, &csi.VolumeUsage{
+			Available: requirePositive(inodesFree),
+			Total:     requirePositive(inodes),
+			Used:      requirePositive(inodesUsed),
+			Unit:      csi.VolumeUsage_INODES,
+		})
+	}
+
+	return res, nil
 }
 
 // requirePositive returns the value for `x` when it is greater or equal to 0,

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -87,7 +87,7 @@ func TestFilesystemNodeGetVolumeStats(t *testing.T) {
 
 	// retry until a mountpoint is found
 	for {
-		stats, err := FilesystemNodeGetVolumeStats(context.TODO(), cwd)
+		stats, err := FilesystemNodeGetVolumeStats(context.TODO(), cwd, true)
 		if err != nil && cwd != "/" && strings.HasSuffix(err.Error(), "is not mounted") {
 			// try again with the parent directory
 			cwd = filepath.Dir(cwd)

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -1221,7 +1221,7 @@ func (ns *NodeServer) NodeGetVolumeStats(
 	}
 
 	if stat.Mode().IsDir() {
-		return csicommon.FilesystemNodeGetVolumeStats(ctx, targetPath)
+		return csicommon.FilesystemNodeGetVolumeStats(ctx, targetPath, true)
 	} else if (stat.Mode() & os.ModeDevice) == os.ModeDevice {
 		return blockNodeGetVolumeStats(ctx, targetPath)
 	}


### PR DESCRIPTION
CephFS does not have a concept of "free inodes", inodes get allocated on-demand in the filesystem.

This confuses alerting managers that expect a (high) number of free inodes, and warnings get produced if the number of free inodes is not high enough. This causes alerts to always get reported for CephFS.

To prevent the false-positive alerts from happening, the NodeGetVolumeStats procedure for CephFS (and CephNFS) will not contain inodes in the reply anymore.

See-also: https://bugzilla.redhat.com/2128263
Signed-off-by: Niels de Vos <ndevos@redhat.com>
(cherry picked from commit b7703faf37f5905f8e1c83f0c15a01df6cdbb181)
(cherry picked from commit 8037f69311344b1b2061a582e73415b7da371317)
