### PR TITLE
BUG 2155502: cephfs: skip expand for BackingSnapshot volume

### DIFF
--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -299,7 +299,7 @@ func (cs *ControllerServer) CreateVolume(
 	if vID != nil {
 		volClient := core.NewSubVolume(volOptions.GetConnection(), &volOptions.SubVolume,
 			volOptions.ClusterID, cs.ClusterName, cs.SetMetadata)
-		if sID != nil || pvID != nil && !volOptions.BackingSnapshot {
+		if (sID != nil || pvID != nil) && !volOptions.BackingSnapshot {
 			err = volClient.ExpandVolume(ctx, volOptions.Size)
 			if err != nil {
 				purgeErr := volClient.PurgeVolume(ctx, false)


### PR DESCRIPTION
We should not call ExpandVolume for the BackingSnapshot subvolume as their wont be any real subvolume created for it, and even if we call it the ExpandVolume will fail as there is no real subvolume that exists.

This commits fixes by adjusting the `if` check to ensure that ExpandVolume will only be called either the
VolumeRequest is to create from a snapshot or volume, and BackingSnapshot is not true.

sample code here https://go.dev/play/p/PI2tNii5tTg

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit f7796081d39874ff7d429270e2f53039b92e9b72)

