### PR TITLE
[DOWNSTREAM-ONLY] ci: disable dependabot PR creation for `/api` dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-backport.md
@@ -11,4 +11,3 @@ I hereby confirm that:
 - [ ] branches for higher versions of the project have this change merged
 - [ ] this PR is not *downstream-only*, if that was the case, I would have
   explained its need very clearly
-

--- a/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/redhat-sync.md
@@ -6,4 +6,3 @@ The most important recent changes that we want included are:
 - the new foz bar baz works flawlessly
 - this addresses a bug where users are facing issues with XYZ
 - ...
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,8 @@ updates:
     commit-message:
       prefix: "rebase"
   - package-ecosystem: "gomod"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/api"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot does not need to report available updates for vendored dependencies in the downstream repository. Updates to dependencies are synced from the upstream repository when needed. There is also the "Upstream First" requirement, which we follow closely.

See-also: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)
- `/retest all`: run this in case the CentOS CI failed to start/report any test
  progress or results

</details>
