### PR TITLE
nfs: add support for `clients` in the StorageClass

### DIFF
--- a/examples/nfs/storageclass.yaml
+++ b/examples/nfs/storageclass.yaml
@@ -51,5 +51,11 @@ parameters:
   # This option is available with Ceph v17.2.6 and newer.
   # secTypes: <sectype-list>
 
+  # (optional) The clients parameter in the storage class is used to limit
+  # access to the export to the set of hostnames, networks or ip addresses
+  # specified.  The <client-list> is a comma delimited string,
+  # for example: "192.168.0.10,192.168.1.0/8"
+  # clients: <client-list>
+
 reclaimPolicy: Delete
 allowVolumeExpansion: true

--- a/internal/nfs/controller/volume.go
+++ b/internal/nfs/controller/volume.go
@@ -132,6 +132,7 @@ func (nv *NFSVolume) CreateExport(backend *csi.Volume) error {
 	nfsCluster := backend.VolumeContext["nfsCluster"]
 	path := backend.VolumeContext["subvolumePath"]
 	secTypes := backend.VolumeContext["secTypes"]
+	clients := backend.VolumeContext["clients"]
 
 	err := nv.setNFSCluster(nfsCluster)
 	if err != nil {
@@ -155,6 +156,10 @@ func (nv *NFSVolume) CreateExport(backend *csi.Volume) error {
 		for _, secType := range strings.Split(secTypes, ",") {
 			export.SecType = append(export.SecType, nfs.SecType(secType))
 		}
+	}
+
+	if clients != "" {
+		export.ClientAddr = strings.Split(clients, ",")
 	}
 
 	_, err = nfsa.CreateCephFSExport(export)


### PR DESCRIPTION
The clients parameter in the storage class is used to limit access to the export to the set of hostnames, networks or ip addresses specified.

/cc spuiuk
/assign Madhu-1