### PR TITLE
rbd: do not execute rbd sparsify when volume is in use

### DIFF
--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -63,4 +63,6 @@ var (
 	ErrFetchingMirroringInfo = errors.New("failed to get mirroring info of image")
 	// ErrResyncImageFailed is returned when the operation to resync the image fails.
 	ErrResyncImageFailed = errors.New("failed to resync image")
+	// ErrImageInUse is returned when the image is in use.
+	ErrImageInUse = errors.New("image is in use")
 )


### PR DESCRIPTION
This commit makes sure sparsify() is not run when rbd image is in use.
Running rbd sparsify with workload doing io and too frequently is not desirable.
When a image is in use fstrim is run and sparsify will be run only when image is not mapped.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 98fdadfde77adc16b578e550d4327b6d43ce0a6c)

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contrib