### PR TITLE
BUG 2225420: rbd: do not execute rbd sparsify when volume is in use

### DIFF
--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -18,11 +18,13 @@ package rbd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	rs "github.com/csi-addons/spec/lib/go/reclaimspace"
@@ -68,6 +70,13 @@ func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 	defer rbdVol.Destroy()
 
 	err = rbdVol.Sparsify()
+	if errors.Is(err, rbdutil.ErrImageInUse) {
+		// FIXME: https://github.com/csi-addons/kubernetes-csi-addons/issues/406.
+		// treat sparsify call as no-op if volume is in use.
+		log.DebugLog(ctx, fmt.Sprintf("volume with ID %q is in use, skipping sparsify operation", volumeID))
+
+		return &rs.ControllerReclaimSpaceResponse{}, nil
+	}
 	if err != nil {
 		// TODO: check for different error codes?
 		return nil, status.Errorf(codes.Internal, "failed to sparsify volume %q: %s", rbdVol, err.Error())

--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -44,4 +44,6 @@ var (
 	ErrDecodeClusterIDFromMonsInVolID = errors.New("failed to get clusterID from monitors hash in volID")
 	// ErrUnHealthyMirroredImage is returned when mirrored image is not healthy.
 	ErrUnHealthyMirroredImage = errors.New("mirrored image is not healthy")
+	// ErrImageInUse is returned when the image is in use.
+	ErrImageInUse = errors.New("image is in use")
 )


### PR DESCRIPTION
This commit makes sure sparsify() is not run when rbd image is in use.
Running rbd sparsify with workload doing io and too frequently is not desirable.
When a image is in use fstrim is run and sparsify will be run only when image is not mapped.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 98fdadfde77adc16b578e550d4327b6d43ce0a6c) (cherry picked from commit 60a86ab8772abfaf343c3cac6b476dfd2d70d89d)
