### PR TITLE
BUG 2225433: rbd: do not execute rbd sparsify when volume is in use

### DIFF
--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -45,4 +45,6 @@ var (
 	// ErrLastSyncTimeNotFound is returned when last sync time is not found for
 	// the image.
 	ErrLastSyncTimeNotFound = errors.New("last sync time not found")
+	// ErrImageInUse is returned when the image is in use.
+	ErrImageInUse = errors.New("image is in use")
 )


### PR DESCRIPTION
This commit makes sure sparsify() is not run when rbd image is in use.
Running rbd sparsify with workload doing io and too frequently is not desirable.
When a image is in use fstrim is run and sparsify will be run only when image is not mapped.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 98fdadfde77adc16b578e550d4327b6d43ce0a6c) (cherry picked from commit 60a86ab8772abfaf343c3cac6b476dfd2d70d89d)
