### PR TITLE
Revert "BUG 2225420: rbd: do not execute rbd sparsify when volume is in use"

### DIFF
--- a/internal/csi-addons/rbd/reclaimspace.go
+++ b/internal/csi-addons/rbd/reclaimspace.go
@@ -18,13 +18,11 @@ package rbd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	rbdutil "github.com/ceph/ceph-csi/internal/rbd"
 	"github.com/ceph/ceph-csi/internal/util"
-	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	rs "github.com/csi-addons/spec/lib/go/reclaimspace"
@@ -70,13 +68,6 @@ func (rscs *ReclaimSpaceControllerServer) ControllerReclaimSpace(
 	defer rbdVol.Destroy()
 
 	err = rbdVol.Sparsify()
-	if errors.Is(err, rbdutil.ErrImageInUse) {
-		// FIXME: https://github.com/csi-addons/kubernetes-csi-addons/issues/406.
-		// treat sparsify call as no-op if volume is in use.
-		log.DebugLog(ctx, fmt.Sprintf("volume with ID %q is in use, skipping sparsify operation", volumeID))
-
-		return &rs.ControllerReclaimSpaceResponse{}, nil
-	}
 	if err != nil {
 		// TODO: check for different error codes?
 		return nil, status.Errorf(codes.Internal, "failed to sparsify volume %q: %s", rbdVol, err.Error())

--- a/internal/rbd/diskusage.go
+++ b/internal/rbd/diskusage.go
@@ -23,18 +23,7 @@ import (
 // Sparsify checks the size of the objects in the RBD image and calls
 // rbd_sparify() to free zero-filled blocks and reduce the storage consumption
 // of the image.
-// This function will return ErrImageInUse if the image is in use, since
-// sparsifying an image on which i/o is in progress is not optimal.
 func (ri *rbdImage) Sparsify() error {
-	inUse, err := ri.isInUse()
-	if err != nil {
-		return fmt.Errorf("failed to check if image is in use: %w", err)
-	}
-	if inUse {
-		// if the image is in use, we should not sparsify it, return ErrImageInUse.
-		return ErrImageInUse
-	}
-
 	image, err := ri.open()
 	if err != nil {
 		return err

--- a/internal/rbd/errors.go
+++ b/internal/rbd/errors.go
@@ -44,6 +44,4 @@ var (
 	ErrDecodeClusterIDFromMonsInVolID = errors.New("failed to get clusterID from monitors hash in volID")
 	// ErrUnHealthyMirroredImage is returned when mirrored image is not healthy.
 	ErrUnHealthyMirroredImage = errors.New("mirrored image is not healthy")
-	// ErrImageInUse is returned when the image is in use.
-	ErrImageInUse = errors.New("image is in use")
 )


### PR DESCRIPTION
Reverts red-hat-storage/ceph-csi#170
The pr had a invalid-bug label and should not have merged.
