### PR TITLE
[DOWNSTREAM-ONLY] update OWNERS to reflect current team

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,10 +1,10 @@
 aliases:
   ceph-csi-team:
     - agarwal-mudit
-    - humblec
+    - karthik-us
     - madhu-1
     - nixpanic
-    - rakshith-r
-    - yati1998
     - pkalever
+    - rakshith-r
     - riya-singhal31
+    - yati1998


### PR DESCRIPTION
Karthik joined the team, and Humble left a while ago already.

Upstream does not use the `OWNERS` or `OWNERS_ALIASES` files, there is no upstream equivalent for this.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

- `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
