### PR TITLE
BUG 2242121:  cephfs: safeguard localClusterState struct from race conditions 

### DIFF
--- a/internal/cephfs/core/metadata.go
+++ b/internal/cephfs/core/metadata.go
@@ -51,6 +51,32 @@ func (s *subVolumeClient) isUnsupportedSubVolMetadata(err error) bool {
 	return true
 }
 
+// isSubVolumeGroupCreated returns true if subvolume group is created.
+func (s *subVolumeClient) isSubVolumeGroupCreated() bool {
+	newLocalClusterState(s.clusterID)
+	clusterAdditionalInfo[s.clusterID].subVolumeGroupsRWMutex.RLock()
+	defer clusterAdditionalInfo[s.clusterID].subVolumeGroupsRWMutex.RUnlock()
+
+	if clusterAdditionalInfo[s.clusterID].subVolumeGroupsCreated == nil {
+		return false
+	}
+
+	return clusterAdditionalInfo[s.clusterID].subVolumeGroupsCreated[s.SubvolumeGroup]
+}
+
+// updateSubVolumeGroupCreated updates subvolume group created map.
+// If the map is nil, it creates a new map and updates it.
+func (s *subVolumeClient) updateSubVolumeGroupCreated(state bool) {
+	clusterAdditionalInfo[s.clusterID].subVolumeGroupsRWMutex.Lock()
+	defer clusterAdditionalInfo[s.clusterID].subVolumeGroupsRWMutex.Unlock()
+
+	if clusterAdditionalInfo[s.clusterID].subVolumeGroupsCreated == nil {
+		clusterAdditionalInfo[s.clusterID].subVolumeGroupsCreated = make(map[string]bool)
+	}
+
+	clusterAdditionalInfo[s.clusterID].subVolumeGroupsCreated[s.SubvolumeGroup] = state
+}
+
 // setMetadata sets custom metadata on the subvolume in a volume as a
 // key-value pair.
 func (s *subVolumeClient) setMetadata(key, value string) error {


### PR DESCRIPTION
 -[cephfs: safeguard localClusterState struct from race conditions](https://github.com/red-hat-storage/ceph-csi/commit/16c6ba8bc4577ff958c5e4d7876f56f9f1e72103) 

Multiple go-routines may simultaneously check for a clusterID's
presence in clusterAdditionalInfo and create an entry if it is
absent. This set of operation needs to be serialized.

Therefore, this commit safeguards clusterAdditionalInfo map
from concurrent writes with a mutex to prevent the above problem.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/ceph-csi/commit/82f1323af48512b4201b2ca973ac9063eb24b8bf)

- [cephfs: safeguard subVolumeGroupCreated map from race condition](https://github.com/red-hat-storage/ceph-csi/commit/113eebfd4c4a278a868cdc5d31c95400567ee6dd) 

Multiple go-routines may simultaneously create the
subVolumeGroupCreated map or  write into it
for a particular group.

This commit safeguards subVolumeGroupCreated map
from concurrent creation/writes while allowing for multiple
readers.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/ceph-csi/commit/d516a1d66d84e9fa62fc3e58d429f89205851741)

/cc @red-hat-storage/ceph-csi-admins 