### PR TITLE
BUG 2246388: fix: Invalid "invalid encryption kms configuration" error

### DIFF
--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"strconv"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -342,8 +341,14 @@ func ParseEncryptionOpts(
 		encrypted, kmsID string
 	)
 	encrypted, ok = volOptions["encrypted"]
-	val, _ := strconv.ParseBool(encrypted)
-	if !ok || !val{
+	if !ok {
+		return "", util.EncryptionTypeNone, nil
+	}
+	ok, err = strconv.ParseBool(encrypted)
+	if err != nil {
+		return "", util.EncryptionTypeInvalid, err
+	}
+	if !ok {
 		return "", util.EncryptionTypeNone, nil
 	}
 	ok, err = strconv.ParseBool(encrypted)

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"strconv"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -341,7 +342,8 @@ func ParseEncryptionOpts(
 		encrypted, kmsID string
 	)
 	encrypted, ok = volOptions["encrypted"]
-	if !ok {
+	val, _ := strconv.ParseBool(encrypted)
+	if !ok || !val{
 		return "", util.EncryptionTypeNone, nil
 	}
 	ok, err = strconv.ParseBool(encrypted)


### PR DESCRIPTION
this commit adds the validation for encryption
value as false, and sets the type as none

Backported PR for, https://github.com/ceph/ceph-csi/pull/3854 

https://bugzilla.redhat.com/show_bug.cgi?id=2246388 
Signed-off-by: riya-singhal31 <rsinghal@redhat.com>
