### PR TITLE
BUG 2246388: fix: Invalid "invalid encryption kms configuration" error

### DIFF
--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -2882,7 +2882,6 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
-
 			By("validate RBD static FileSystem PVC", func() {
 				err := validateRBDStaticPV(f, appPath, false, false)
 				if err != nil {

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -191,7 +191,7 @@ func (cs *ControllerServer) parseVolCreateRequest(
 	// get the owner of the PVC which is required for few encryption related operations
 	rbdVol.Owner = k8s.GetOwner(req.GetParameters())
 
-	err = rbdVol.initKMS(ctx, req.GetParameters(), req.GetSecrets())
+	err = rbdVol.initKMS(req.GetParameters(), req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"strconv"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -341,7 +342,8 @@ func ParseEncryptionOpts(
 		encrypted, kmsID string
 	)
 	encrypted, ok = volOptions["encrypted"]
-	if !ok {
+	val, _ := strconv.ParseBool(encrypted)
+	if !ok || !val{
 		return "", util.EncryptionTypeNone, nil
 	}
 	kmsID, err = util.FetchEncryptionKMSID(encrypted, volOptions["encryptionKMSID"])

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -110,7 +110,7 @@ func (ri *rbdImage) isFileEncrypted() bool {
 }
 
 func IsFileEncrypted(ctx context.Context, volOptions map[string]string) (bool, error) {
-	_, encType, err := ParseEncryptionOpts(ctx, volOptions, util.EncryptionTypeInvalid)
+	_, encType, err := ParseEncryptionOpts(volOptions, util.EncryptionTypeInvalid)
 	if err != nil {
 		return false, err
 	}
@@ -306,8 +306,8 @@ func (rv *rbdVolume) openEncryptedDevice(ctx context.Context, devicePath string)
 	return mapperFilePath, nil
 }
 
-func (ri *rbdImage) initKMS(ctx context.Context, volOptions, credentials map[string]string) error {
-	kmsID, encType, err := ParseEncryptionOpts(ctx, volOptions, rbdDefaultEncryptionType)
+func (ri *rbdImage) initKMS(volOptions, credentials map[string]string) error {
+	kmsID, encType, err := ParseEncryptionOpts(volOptions, rbdDefaultEncryptionType)
 	if err != nil {
 		return err
 	}
@@ -332,7 +332,6 @@ func (ri *rbdImage) initKMS(ctx context.Context, volOptions, credentials map[str
 
 // ParseEncryptionOpts returns kmsID and sets Owner attribute.
 func ParseEncryptionOpts(
-	ctx context.Context,
 	volOptions map[string]string,
 	fallbackEncType util.EncryptionType,
 ) (string, util.EncryptionType, error) {

--- a/internal/rbd/encryption.go
+++ b/internal/rbd/encryption.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 
 	kmsapi "github.com/ceph/ceph-csi/internal/kms"
 	"github.com/ceph/ceph-csi/internal/util"
@@ -341,8 +341,14 @@ func ParseEncryptionOpts(
 		encrypted, kmsID string
 	)
 	encrypted, ok = volOptions["encrypted"]
-	val, _ := strconv.ParseBool(encrypted)
-	if !ok || !val{
+	if !ok {
+		return "", util.EncryptionTypeNone, nil
+	}
+	ok, err = strconv.ParseBool(encrypted)
+	if err != nil {
+		return "", util.EncryptionTypeInvalid, err
+	}
+	if !ok {
 		return "", util.EncryptionTypeNone, nil
 	}
 	kmsID, err = util.FetchEncryptionKMSID(encrypted, volOptions["encryptionKMSID"])

--- a/internal/rbd/encryption_test.go
+++ b/internal/rbd/encryption_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/ceph/ceph-csi/internal/util"
+)
+
+func TestParseEncryptionOpts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		testName     string
+		volOptions   map[string]string
+		fallbackType util.EncryptionType
+		expectedKMS  string
+		expectedEnc  util.EncryptionType
+		expectedErr  bool
+	}{
+		{
+			testName: "No Encryption Option",
+			volOptions: map[string]string{
+				"foo": "bar",
+			},
+			fallbackType: util.EncryptionTypeBlock,
+			expectedKMS:  "",
+			expectedEnc:  util.EncryptionTypeNone,
+			expectedErr:  false,
+		},
+		{
+			testName: "Encrypted as false",
+			volOptions: map[string]string{
+				"encrypted": "false",
+			},
+			fallbackType: util.EncryptionTypeBlock,
+			expectedKMS:  "",
+			expectedEnc:  util.EncryptionTypeNone,
+			expectedErr:  false,
+		},
+		{
+			testName: "Encrypted as invalid string",
+			volOptions: map[string]string{
+				"encrypted": "notbool",
+			},
+			fallbackType: util.EncryptionTypeBlock,
+			expectedKMS:  "",
+			expectedEnc:  util.EncryptionTypeInvalid,
+			expectedErr:  true,
+		},
+		{
+			testName: "Valid Encryption Option With KMS ID",
+			volOptions: map[string]string{
+				"encrypted":       "true",
+				"encryptionKMSID": "valid-kms-id",
+			},
+			fallbackType: util.EncryptionTypeBlock,
+			expectedKMS:  "valid-kms-id",
+			expectedEnc:  util.EncryptionTypeBlock,
+			expectedErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		newtt := tt
+		t.Run(newtt.testName, func(t *testing.T) {
+			t.Parallel()
+			actualKMS, actualEnc, actualErr := ParseEncryptionOpts(
+				newtt.volOptions,
+				newtt.fallbackType,
+			)
+			if actualKMS != newtt.expectedKMS {
+				t.Errorf("Expected KMS ID: %s, but got: %s", newtt.expectedKMS, actualKMS)
+			}
+
+			if actualEnc != newtt.expectedEnc {
+				t.Errorf("Expected Encryption Type: %v, but got: %v", newtt.expectedEnc, actualEnc)
+			}
+
+			if (actualErr != nil) != newtt.expectedErr {
+				t.Errorf("expected error %v but got %v", newtt.expectedErr, actualErr)
+			}
+		})
+	}
+}

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -224,7 +224,7 @@ func (ns *NodeServer) populateRbdVol(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	err = rv.initKMS(ctx, req.GetVolumeContext(), req.GetSecrets())
+	err = rv.initKMS(req.GetVolumeContext(), req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -572,7 +572,7 @@ func RegenerateJournal(
 
 	rbdVol.Owner = owner
 
-	kmsID, encryptionType, err = ParseEncryptionOpts(ctx, volumeAttributes, util.EncryptionTypeNone)
+	kmsID, encryptionType, err = ParseEncryptionOpts(volumeAttributes, util.EncryptionTypeNone)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Backport of ceph/ceph-csi#3854, to include the following commits:

- rbd: add check for EncryptionTypeNone
- rbd: remove context where its not being used
- rbd: add e2e for encryption as false
- rbd: add unit test for ParseEncryptionOpts

I hereby confirm that:

- [x] this change is in the upstream project (ceph/ceph-csi#3854)
- [x] this change is in the devel branch of this project (see #163)
- [x] branches for higher versions of the project have this change merged
- [x] this PR is not *downstream-only*, if that was the case, I would have
  explained its need very clearly
