### PR TITLE
BUG 2249600: cephfs: set Pool parameter to empty for Snapshot-backed volumes

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -44,6 +44,7 @@ var (
 	cephFSExamplePath     = examplePath + "cephfs/"
 	subvolumegroup        = "e2e"
 	fileSystemName        = "myfs"
+	fileSystemPoolName    = "myfs-replicated"
 )
 
 func deployCephfsPlugin() {
@@ -1613,6 +1614,7 @@ var _ = Describe(cephfsType, func() {
 						scOpts := map[string]string{
 							"encrypted":       "true",
 							"encryptionKMSID": kmsID,
+							"pool":            fileSystemPoolName,
 						}
 
 						err = createCephfsStorageClass(f.ClientSet, f, true, scOpts)

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -542,9 +542,10 @@ func (vo *VolumeOptions) populateVolumeOptionsFromBackingSnapshot(
 		return fmtBackingSnapshotOptionMismatch("clusterID", vo.ClusterID, parentBackingSnapVolOpts.ClusterID)
 	}
 
-	if vo.Pool != "" {
-		return errors.New("cannot set pool for snapshot-backed volume")
-	}
+	// Pool parameter is optional and only used to set 'pool_layout' argument for
+	// subvolume and subvolume clone create commands.
+	// Setting this to empty since it is not used with Snapshot-backed volume.
+	vo.Pool = ""
 
 	if vo.MetadataPool != parentBackingSnapVolOpts.MetadataPool {
 		return fmtBackingSnapshotOptionMismatch("MetadataPool", vo.MetadataPool, parentBackingSnapVolOpts.MetadataPool)


### PR DESCRIPTION
Set VolumeOptions.Pool parameter to empty for Snapshot-backed volumes. This Pool parameter is optional and  only used as 'pool-layout' parameter during subvolume and subvolume clone create request in cephcsi and not used for Snapshot-backed volume at all.
It is not saved anywhere for use in subsequent operations after create too. Therefore, We can set it to empty and not error out.

Signed-off-by: rakshith-r <rar@redhat.com>
(cherry picked from commit f1e9d8084a9f4cada37ceecc1d1329ce9409bfeb)

/cc @red-hat-storage/ceph-csi-admins 