### PR TITLE
BUG 2264002: rbd: log sitestatuses and description

### DIFF
--- a/internal/csi-addons/rbd/replication_test.go
+++ b/internal/csi-addons/rbd/replication_test.go
@@ -218,6 +218,7 @@ func TestGetSchedulingDetails(t *testing.T) {
 }
 
 func TestCheckVolumeResyncStatus(t *testing.T) {
+	ctx := context.TODO()
 	t.Parallel()
 	tests := []struct {
 		name    string
@@ -253,7 +254,7 @@ func TestCheckVolumeResyncStatus(t *testing.T) {
 		ts := tt
 		t.Run(ts.name, func(t *testing.T) {
 			t.Parallel()
-			if err := checkVolumeResyncStatus(ts.args); (err != nil) != ts.wantErr {
+			if err := checkVolumeResyncStatus(ctx, ts.args); (err != nil) != ts.wantErr {
 				t.Errorf("checkVolumeResyncStatus() error = %v, expect error = %v", err, ts.wantErr)
 			}
 		})
@@ -399,6 +400,7 @@ func TestCheckRemoteSiteStatus(t *testing.T) {
 
 func TestValidateLastSyncInfo(t *testing.T) {
 	t.Parallel()
+	ctx := context.TODO()
 	duration, err := time.ParseDuration(strconv.Itoa(int(56743)) + "s")
 	if err != nil {
 		t.Errorf("failed to parse duration)")
@@ -502,7 +504,7 @@ func TestValidateLastSyncInfo(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			teststruct, err := getLastSyncInfo(tt.description)
+			teststruct, err := getLastSyncInfo(ctx, tt.description)
 			if err != nil && !strings.Contains(err.Error(), tt.expectedErr) {
 				// returned error
 				t.Errorf("getLastSyncInfo() returned error, expected: %v, got: %v",

--- a/internal/csi-common/utils.go
+++ b/internal/csi-common/utils.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/csi-addons/spec/lib/go/replication"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc"
@@ -132,6 +133,27 @@ func getReqID(req interface{}) string {
 		reqID = r.VolumeId
 
 	case *csi.NodeExpandVolumeRequest:
+		reqID = r.VolumeId
+
+	case *csi.CreateVolumeGroupSnapshotRequest:
+		reqID = r.Name
+	case *csi.DeleteVolumeGroupSnapshotRequest:
+		reqID = r.GroupSnapshotId
+	case *csi.GetVolumeGroupSnapshotRequest:
+		reqID = r.GroupSnapshotId
+
+	// Replication
+	case *replication.EnableVolumeReplicationRequest:
+		reqID = r.VolumeId
+	case *replication.DisableVolumeReplicationRequest:
+		reqID = r.VolumeId
+	case *replication.PromoteVolumeRequest:
+		reqID = r.VolumeId
+	case *replication.DemoteVolumeRequest:
+		reqID = r.VolumeId
+	case *replication.ResyncVolumeRequest:
+		reqID = r.VolumeId
+	case *replication.GetVolumeReplicationInfoRequest:
 		reqID = r.VolumeId
 	}
 

--- a/internal/csi-common/utils_test.go
+++ b/internal/csi-common/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	mount "k8s.io/mount-utils"
@@ -63,6 +64,35 @@ func TestGetReqID(t *testing.T) {
 			VolumeId: fakeID,
 		},
 		&csi.NodeExpandVolumeRequest{
+			VolumeId: fakeID,
+		},
+
+		&csi.CreateVolumeGroupSnapshotRequest{
+			Name: fakeID,
+		},
+		&csi.DeleteVolumeGroupSnapshotRequest{
+			GroupSnapshotId: fakeID,
+		},
+		&csi.GetVolumeGroupSnapshotRequest{
+			GroupSnapshotId: fakeID,
+		},
+
+		&replication.EnableVolumeReplicationRequest{
+			VolumeId: fakeID,
+		},
+		&replication.DisableVolumeReplicationRequest{
+			VolumeId: fakeID,
+		},
+		&replication.PromoteVolumeRequest{
+			VolumeId: fakeID,
+		},
+		&replication.DemoteVolumeRequest{
+			VolumeId: fakeID,
+		},
+		&replication.ResyncVolumeRequest{
+			VolumeId: fakeID,
+		},
+		&replication.GetVolumeReplicationInfoRequest{
 			VolumeId: fakeID,
 		},
 	}


### PR DESCRIPTION
This commit logs sitestatues and description in
GetVolumeReplicationInfo RPC call for better
debuging.

Fixes: #4430

Signed-off-by: Yati Padia <ypadia@redhat.com>
(cherry picked from commit cdc73a73519282abb13db3fbf25c77ed6110d46d)
