### PR TITLE
DOWNSTREAM-ONLY: update ceph-csi-team OWNER alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,5 +7,4 @@ aliases:
     - nixpanic
     - pkalever
     - rakshith-r
-    - riya-singhal31
     - yati1998


### PR DESCRIPTION
Riya left the company, she is not part of the red-hat-storage organization anymore.

/cc @sunilheggodu