### PR TITLE
BUG 2264900: rbd: add ParentInTrash parameter in rbdImage struct

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -146,6 +146,8 @@ type rbdImage struct {
 
 	// Set metadata on volume
 	EnableMetadata bool
+	// ParentInTrash indicates the parent image is in trash.
+	ParentInTrash bool
 }
 
 // rbdVolume represents a CSI volume and its RBD image specifics.
@@ -1613,6 +1615,7 @@ func (ri *rbdImage) getImageInfo() error {
 	} else {
 		ri.ParentName = parentInfo.Image.ImageName
 		ri.ParentPool = parentInfo.Image.PoolName
+		ri.ParentInTrash = parentInfo.Image.Trash
 	}
 	// Get image creation time
 	tm, err := image.GetCreateTimestamp()
@@ -1631,7 +1634,9 @@ func (ri *rbdImage) getParent() (*rbdImage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ri.ParentName == "" {
+	// The image may not have a parent or the parent maybe in trash.
+	// Return nil in both the cases.
+	if ri.ParentName == "" || ri.ParentInTrash {
 		return nil, nil
 	}
 


### PR DESCRIPTION
This commit adds ParentInTrash parameter in rbdImage struct and makes use of it in getParent() function in order to avoid error in case the parent is present but in trash.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit c34b31ee05d56e7fcf0597f42b7ed5e2913a3cfd)
