### PR TITLE
BUG 2266237: cleanup: incorrect fuserecovery logging

### DIFF
--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -213,8 +213,10 @@ func (ns *NodeServer) NodeStageVolume(
 
 	// Check if the volume is already mounted
 
-	if err = ns.tryRestoreFuseMountInNodeStage(ctx, mnt, stagingTargetPath); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to try to restore FUSE mounts: %v", err)
+	if _, ok := mnt.(*mounter.FuseMounter); ok {
+		if err = ns.tryRestoreFuseMountInNodeStage(ctx, stagingTargetPath); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to try to restore FUSE mounts: %v", err)
+		}
 	}
 
 	isMnt, err := util.IsMountPoint(ns.Mounter, stagingTargetPath)
@@ -448,23 +450,37 @@ func (ns *NodeServer) NodePublishVolume(
 	targetPath := req.GetTargetPath()
 	volID := fsutil.VolumeID(req.GetVolumeId())
 
+	volOptions := &store.VolumeOptions{}
+	defer volOptions.Destroy()
+
+	if err := volOptions.DetectMounter(req.GetVolumeContext()); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to detect mounter for volume %s: %v", volID, err.Error())
+	}
+
+	volMounter, err := mounter.New(volOptions)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create mounter for volume %s: %v", volID, err.Error())
+	}
+
 	// Considering kubelet make sure the stage and publish operations
 	// are serialized, we dont need any extra locking in nodePublish
 
-	if err := util.CreateMountPoint(targetPath); err != nil {
+	if err = util.CreateMountPoint(targetPath); err != nil {
 		log.ErrorLog(ctx, "failed to create mount point at %s: %v", targetPath, err)
 
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if err := ns.tryRestoreFuseMountsInNodePublish(
-		ctx,
-		volID,
-		stagingTargetPath,
-		targetPath,
-		req.GetVolumeContext(),
-	); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to try to restore FUSE mounts: %v", err)
+	if _, ok := volMounter.(*mounter.FuseMounter); ok {
+		if err = ns.tryRestoreFuseMountsInNodePublish(
+			ctx,
+			volID,
+			stagingTargetPath,
+			targetPath,
+			req.GetVolumeContext(),
+		); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to try to restore FUSE mounts: %v", err)
+		}
 	}
 
 	if req.GetReadonly() {

--- a/internal/cephfs/store/volumeoptions.go
+++ b/internal/cephfs/store/volumeoptions.go
@@ -151,6 +151,10 @@ func validateMounter(m string) error {
 	return nil
 }
 
+func (v *VolumeOptions) DetectMounter(options map[string]string) error {
+	return extractMounter(&v.Mounter, options)
+}
+
 func extractMounter(dest *string, options map[string]string) error {
 	if err := extractOptionalOption(dest, "mounter", options); err != nil {
 		return err

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -338,12 +338,6 @@ func IsCorruptedMountError(err error) bool {
 	return mount.IsCorruptedMnt(err)
 }
 
-// ReadMountInfoForProc reads /proc/<PID>/mountpoint and marshals it into
-// MountInfo structs.
-func ReadMountInfoForProc(proc string) ([]mount.MountInfo, error) {
-	return mount.ParseMountInfo(fmt.Sprintf("/proc/%s/mountinfo", proc))
-}
-
 // Mount mounts the source to target path.
 func Mount(mounter mount.Interface, source, target, fstype string, options []string) error {
 	return mounter.MountSensitiveWithoutSystemd(source, target, fstype, options, nil)

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -8,7 +8,7 @@
 # little different.
 #
 
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:39
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go


### PR DESCRIPTION
cleanup: incorrect fuserecovery logging
This commit make sure that logs fuserecovery.go is only logged
when the chosen mount is FUSE.

(cherry picked from commit 0e61b82)