### PR TITLE
BUG 2303177: util: exclude empty label values for crushlocation map

### DIFF
--- a/internal/util/crushlocation.go
+++ b/internal/util/crushlocation.go
@@ -48,6 +48,10 @@ func getCrushLocationMap(crushLocationLabels string, nodeLabels map[string]strin
 	// Determine values for requested labels from node labels
 	crushLocationMap := make(map[string]string, len(labelsIn))
 	for key, value := range nodeLabels {
+		// label with empty value is not considered.
+		if value == "" {
+			continue
+		}
 		if _, ok := labelsIn[key]; !ok {
 			continue
 		}

--- a/internal/util/crushlocation_test.go
+++ b/internal/util/crushlocation_test.go
@@ -100,6 +100,17 @@ func Test_getCrushLocationMap(t *testing.T) {
 			},
 			want: map[string]string{"host": "worker-1"},
 		},
+		{
+			name: "matching crushlocation and node labels with empty value",
+			args: input{
+				crushLocationLabels: "topology.io/region,topology.io/zone",
+				nodeLabels: map[string]string{
+					"topology.io/region": "region1",
+					"topology.io/zone":   "",
+				},
+			},
+			want: map[string]string{"region": "region1"},
+		},
 	}
 	for _, tt := range tests {
 		currentTT := tt


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit resolves a bug where node labels with empty values
are processed for the `crush_location` mount option,
leading to invalid mount options and subsequent mount failures.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
