### PR TITLE
BUG 2303181: util: exclude empty label values for crushlocation map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ ifeq ($(HAVE_CPUSET),1)
     CPUSET ?= --cpuset-cpus=0-${CPUS}
 endif
 
+ifneq ($(GITHUB_ACTION),)
+    # see https://github.com/containers/podman/issues/21012
+    SECURITY_OPT ?= --security-opt seccomp=unconfined
+endif
+
 CSI_IMAGE_NAME=$(if $(ENV_CSI_IMAGE_NAME),$(ENV_CSI_IMAGE_NAME),quay.io/cephcsi/cephcsi)
 CSI_IMAGE_VERSION=$(shell . $(CURDIR)/build.env ; echo $${CSI_IMAGE_VERSION})
 CSI_IMAGE=$(CSI_IMAGE_NAME):$(CSI_IMAGE_VERSION)
@@ -224,7 +229,7 @@ ifeq ($(USE_PULLED_IMAGE),no)
 .test-container-id: .container-cmd build.env scripts/Dockerfile.test
 	[ ! -f .test-container-id ] || $(CONTAINER_CMD) rmi $(CSI_IMAGE_NAME):test
 	$(RM) .test-container-id
-	$(CONTAINER_CMD) build $(CPUSET) --build-arg GOARCH=$(GOARCH) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
+	$(CONTAINER_CMD) build $(CPUSET) $(SECURITY_OPT) --build-arg GOARCH=$(GOARCH) -t $(CSI_IMAGE_NAME):test -f ./scripts/Dockerfile.test .
 	$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CSI_IMAGE_NAME):test > .test-container-id
 else
 # create the .test-container-id file based on the pulled image

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -22,8 +22,8 @@ curl -X GET http://10.109.65.142:8080/metrics 2>/dev/null | grep csi
 csi_liveness 1
 ```
 
-Promethues can be deployed through the promethues operator described [here](https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html).
-The [service-monitor](../deploy/service-monitor.yaml) will tell promethues how
+Prometheus can be deployed through the prometheus operator described [here](https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html).
+The [service-monitor](../deploy/service-monitor.yaml) will tell prometheus how
 to pull metrics out of CSI.
 
 Each CSI pod has a service to expose the endpoint to prometheus. By default, rbd

--- a/examples/rbd/storageclass.yaml
+++ b/examples/rbd/storageclass.yaml
@@ -124,7 +124,7 @@ parameters:
    #   "file": Enable file encryption on the mounted filesystem
    #   "block": Encrypt RBD block device
    # When unspecified assume type "block". "file" and "block" are
-   # mutally exclusive.
+   # mutually exclusive.
    # encryptionType: "block"
 
    # (optional) Use external key management system for encryption passphrases by

--- a/internal/health-checker/checker.go
+++ b/internal/health-checker/checker.go
@@ -37,7 +37,7 @@ type checker struct {
 	// timeout contains the delay (interval + timeout)
 	timeout time.Duration
 
-	// mutex protects against concurrent access to healty, err and
+	// mutex protects against concurrent access to healthy, err and
 	// lastUpdate
 	mutex *sync.RWMutex
 

--- a/internal/util/crushlocation.go
+++ b/internal/util/crushlocation.go
@@ -48,6 +48,10 @@ func getCrushLocationMap(crushLocationLabels string, nodeLabels map[string]strin
 	// Determine values for requested labels from node labels
 	crushLocationMap := make(map[string]string, len(labelsIn))
 	for key, value := range nodeLabels {
+		// label with empty value is not considered.
+		if value == "" {
+			continue
+		}
 		if _, ok := labelsIn[key]; !ok {
 			continue
 		}

--- a/internal/util/crushlocation_test.go
+++ b/internal/util/crushlocation_test.go
@@ -60,7 +60,7 @@ func Test_getCrushLocationMap(t *testing.T) {
 			want: map[string]string{"zone": "zone1"},
 		},
 		{
-			name: "multuple matching crushlocation and node labels",
+			name: "multiple matching crushlocation and node labels",
 			args: input{
 				crushLocationLabels: "topology.io/zone,topology.io/rack",
 				nodeLabels: map[string]string{

--- a/internal/util/crushlocation_test.go
+++ b/internal/util/crushlocation_test.go
@@ -100,6 +100,17 @@ func Test_getCrushLocationMap(t *testing.T) {
 			},
 			want: map[string]string{"host": "worker-1"},
 		},
+		{
+			name: "matching crushlocation and node labels with empty value",
+			args: input{
+				crushLocationLabels: "topology.io/region,topology.io/zone",
+				nodeLabels: map[string]string{
+					"topology.io/region": "region1",
+					"topology.io/zone":   "",
+				},
+			},
+			want: map[string]string{"region": "region1"},
+		},
 	}
 	for _, tt := range tests {
 		currentTT := tt


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This commit resolves a bug where node labels with empty values
are processed for the `crush_location` mount option,
leading to invalid mount options and subsequent mount failures.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
