### PR TITLE
util: return correct status code for VolumeGroupSnapshot

### DIFF
--- a/internal/cephfs/errors/errors.go
+++ b/internal/cephfs/errors/errors.go
@@ -61,6 +61,9 @@ var (
 
 	// ErrQuiesceInProgress is returned when quiesce operation is in progress.
 	ErrQuiesceInProgress = coreError.New("quiesce operation is in progress")
+
+	// ErrGroupNotFound is returned when volume group snapshot is not found in the backend.
+	ErrGroupNotFound = coreError.New("volume group snapshot not found")
 )
 
 // IsCloneRetryError returns true if the clone error is pending,in-progress

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -721,11 +721,15 @@ func (cs *ControllerServer) DeleteVolumeGroupSnapshot(ctx context.Context,
 
 	vgo, vgsi, err := store.NewVolumeGroupOptionsFromID(ctx, req.GetGroupSnapshotId(), cr)
 	if err != nil {
-		log.ErrorLog(ctx, "failed to get volume group options: %v", err)
-		err = extractDeleteVolumeGroupError(err)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+		if !errors.Is(err, cerrors.ErrGroupNotFound) {
+			log.ErrorLog(ctx, "failed to get volume group options: %v", err)
+			err = extractDeleteVolumeGroupError(err)
+			if err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
 		}
+
+		log.ErrorLog(ctx, "VolumeGroupSnapshot %q doesn't exists", req.GetGroupSnapshotId())
 
 		return &csi.DeleteVolumeGroupSnapshotResponse{}, nil
 	}

--- a/internal/cephfs/store/volumegroup.go
+++ b/internal/cephfs/store/volumegroup.go
@@ -172,6 +172,12 @@ func NewVolumeGroupOptionsFromID(
 		return nil, nil, err
 	}
 
+	if groupAttributes.GroupName == "" {
+		log.ErrorLog(ctx, "volume group snapshot with id %v not found", volumeGroupSnapshotID)
+
+		return nil, nil, cerrors.ErrGroupNotFound
+	}
+
 	vgs.RequestName = groupAttributes.RequestName
 	vgs.FsVolumeGroupSnapshotName = groupAttributes.GroupName
 	vgs.VolumeGroupSnapshotID = volumeGroupSnapshotID

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -195,7 +195,7 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 	vg, err := mgr.GetVolumeGroupByID(ctx, req.GetVolumeGroupId())
 	if err != nil {
 		if errors.Is(err, group.ErrRBDGroupNotFound) {
-			log.DebugLog(ctx, "VolumeGroup %q doesn't exists", req.GetVolumeGroupId())
+			log.ErrorLog(ctx, "VolumeGroup %q doesn't exists", req.GetVolumeGroupId())
 
 			return &volumegroup.DeleteVolumeGroupResponse{}, nil
 		}
@@ -433,9 +433,19 @@ func (vs *VolumeGroupServer) ControllerGetVolumeGroup(
 	// resolve the volume group
 	vg, err := mgr.GetVolumeGroupByID(ctx, req.GetVolumeGroupId())
 	if err != nil {
+		if errors.Is(err, group.ErrRBDGroupNotFound) {
+			log.ErrorLog(ctx, "VolumeGroup %q doesn't exists", req.GetVolumeGroupId())
+
+			return nil, status.Errorf(
+				codes.NotFound,
+				"could not find volume group %q: %s",
+				req.GetVolumeGroupId(),
+				err.Error())
+		}
+
 		return nil, status.Errorf(
-			codes.NotFound,
-			"could not find volume group %q: %s",
+			codes.Internal,
+			"could not fetch volume group %q: %s",
 			req.GetVolumeGroupId(),
 			err.Error())
 	}

--- a/internal/rbd/group/group_snapshot.go
+++ b/internal/rbd/group/group_snapshot.go
@@ -18,6 +18,7 @@ package group
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -69,6 +70,12 @@ func GetVolumeGroupSnapshot(
 
 	attrs, err := vgs.getVolumeGroupAttributes(ctx)
 	if err != nil {
+		if errors.Is(err, ErrRBDGroupNotFound) {
+			log.ErrorLog(ctx, "%v, returning empty volume group snapshot %q", vgs, err)
+
+			return vgs, err
+		}
+
 		return nil, fmt.Errorf("failed to get volume attributes for id %q: %w", vgs, err)
 	}
 

--- a/internal/rbd/group/util.go
+++ b/internal/rbd/group/util.go
@@ -145,7 +145,7 @@ func (cvg *commonVolumeGroup) getVolumeGroupAttributes(ctx context.Context) (*jo
 		attrs = &journal.VolumeGroupAttributes{}
 	}
 
-	if attrs.GroupName == "" || attrs.CreationTime == nil {
+	if attrs.GroupName == "" {
 		log.ErrorLog(ctx, "volume group with id %v not found", cvg.id)
 
 		return nil, ErrRBDGroupNotFound

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -77,7 +77,7 @@ func GetVolumeGroup(
 
 	attrs, err := vg.getVolumeGroupAttributes(ctx)
 	if err != nil {
-		if errors.Is(err, librbd.ErrNotFound) {
+		if errors.Is(err, ErrRBDGroupNotFound) {
 			log.ErrorLog(ctx, "%v, returning empty volume group %q", vg, err)
 
 			return vg, err


### PR DESCRIPTION
Fix status codes that are returned for Get/Delete RPC calls for VolumeGroup/VolumeGroupSnapshot.

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
