### PR TITLE
DFBUGS-1420: rbd: use correct radosnamespace 

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -608,6 +608,10 @@ func RegenerateJournal(
 	if err != nil {
 		return "", err
 	}
+	rbdVol.RadosNamespace, err = util.GetRBDRadosNamespace(util.CsiConfigFile, rbdVol.ClusterID)
+	if err != nil {
+		return "", err
+	}
 
 	if rbdVol.Pool, ok = volumeAttributes["pool"]; !ok {
 		return "", errors.New("required 'pool' parameter missing in volume attributes")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Issue: When an RBD image is created in a non-default namespace, the OMAP data for the PersistentVolume fails to regenerate because it still attempts to locate the RBD image in the default namespace.

This commit ensures the correct radosNamespace is retrieved from the ceph-csi-config.

Signed-off-by: Praveen M <m.praveen@ibm.com>
(cherry picked from commit 8a66575825be125b5c9f1762cc60f7e118e856ce)

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [x] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [x] Documentation has been updated, if necessary.
* [x] Unit tests have been added, if necessary.
* [x] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
