### PR TITLE
DFBUGS-1669: rbd: fix bug in rbdVol.Exists() in PVC-PVC clone case

### DIFF
--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -297,24 +297,28 @@ func (rv *rbdVolume) Exists(ctx context.Context, parentVol *rbdVolume) (bool, er
 	requestSize := rv.VolSize
 	// Fetch on-disk image attributes and compare against request
 	err = rv.getImageInfo()
-	if err != nil {
-		if errors.Is(err, ErrImageNotFound) {
-			// Need to check cloned info here not on createvolume,
-			if parentVol != nil {
-				found, cErr := rv.checkCloneImage(ctx, parentVol)
-				switch {
-				case found && cErr == nil:
-					return true, nil
-				case cErr != nil:
-					return false, cErr
-				}
-			}
-			err = j.UndoReservation(ctx, rv.JournalPool, rv.Pool,
-				rv.RbdImageName, rv.RequestName)
+	switch {
+	case errors.Is(err, ErrImageNotFound) && parentVol != nil:
+		// Need to check cloned info here not on createvolume
+		found, cErr := rv.checkCloneImage(ctx, parentVol)
+		if cErr != nil {
+			return false, cErr
+		}
+
+		if !found {
+			// image not found, undo the reservation
+			err = j.UndoReservation(ctx, rv.JournalPool, rv.Pool, rv.RbdImageName, rv.RequestName)
 
 			return false, err
 		}
 
+	case errors.Is(err, ErrImageNotFound) && parentVol == nil:
+		// image not found, undo the reservation
+		err = j.UndoReservation(ctx, rv.JournalPool, rv.Pool, rv.RbdImageName, rv.RequestName)
+
+		return false, err
+
+	case err != nil:
 		return false, err
 	}
 


### PR DESCRIPTION
# Describe what this PR does #


This commit fixes a bug in rbdVol.Exists() which caused VolID not to be set in PVC-PVC clone case.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit b05d4676798121c180a423f4e66fd2ac37c47645)

