### PR TITLE
DFBUGS-1320: rbd- add check to getVolumeReplicationInfo

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -919,6 +919,10 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	if err != nil {
 		log.ErrorLog(ctx, err.Error())
 
+		if errors.Is(err, librbd.ErrNotExist) {
+			return nil, status.Errorf(codes.NotFound, "failed to get remote status: %v", err)
+		}
+
 		return nil, status.Errorf(codes.Internal, "failed to get remote status: %v", err)
 	}
 


### PR DESCRIPTION
this commit adds a check to getVolumeReplicationInfo to include status not found error while getting the remote status.
This helps the failover to be done even if remote site status is not found

Signed-off-by: yati1998 <ypadia@redhat.com>
(cherry picked from commit a5f6d89171168bcca50f36f7f709953f5265eb60)

