### PR TITLE
[DOWNSTREAM-ONLY] rbd: add support for volume group mirroring

### DIFF
--- a/build.env
+++ b/build.env
@@ -22,7 +22,7 @@ CSI_UPGRADE_VERSION=v3.13.1
 CEPH_CSI_OPERATOR_VERSION=latest
 
 # Ceph version to use
-BASE_IMAGE=quay.io/ceph/ceph:v19
+BASE_IMAGE=quay.ceph.io/ceph-ci/ceph:wip-pkalever-rbd-group-snap-mirror
 CEPH_VERSION=squid
 
 # standard Golang options

--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -8,9 +8,11 @@ FROM ${BASE_IMAGE} as updated_base
 # https://github.com/ceph/ceph-container/issues/2034
 # https://github.com/ceph/ceph-container/issues/2141 are fixed.
 RUN true \
-    && dnf -y reinstall https://download.ceph.com/rpm-${CEPH_VERSION}/el9/noarch/ceph-release-1-1.el9.noarch.rpm \
-    && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
-    && true
+    && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=wip-pkalever-rbd-group-snap-mirror&sha1=4fea9830b879b460834a720470e91d519576bb28" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-wip-pkalever-rbd-group-snap-mirror/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
+     && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
+     && true
 
 RUN mkdir -p /etc/selinux && touch /etc/selinux/config
 

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
+replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453
+
 require (
 	// sigs.k8s.io/controller-runtime wants this version, it gets replaced below
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,6 @@ github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4r
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e h1:Ykum5wAFYzyUi+yW0qQFDsbP9pAuRKTOf+ttMoo1jZ4=
-github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e/go.mod h1:bIS41nqhGmD7gQVoSBu3IYCwCiVEMeIxFU5qaqmC4a8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -605,6 +603,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453 h1:aSVOMbsLGszJJ5YYYcka8MHP8O5CPS1IcYDNsuSktes=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453/go.mod h1:V++4AyPoTN50AtoHAZQ63lN0galqGLFE1b7aS0gO1Es=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -793,6 +793,7 @@ func getGRPCError(err error) error {
 		rbderrors.ErrAborted:            codes.Aborted,
 		rbderrors.ErrFailedPrecondition: codes.FailedPrecondition,
 		rbderrors.ErrUnavailable:        codes.Unavailable,
+		rbderrors.ErrGroupUnavailable:   codes.Unavailable,
 	}
 
 	for e, code := range errorStatusMap {
@@ -884,7 +885,7 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	if err != nil {
 		log.ErrorLog(ctx, "failed to get remote site status for mirror %q: %v", mirror, err)
 
-		if errors.Is(err, librbd.ErrNotExist) {
+		if errors.Is(err, rbderrors.ErrStatusNotFound) {
 			return nil, status.Errorf(codes.NotFound, "failed to get remote status: %v", err)
 		}
 

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -256,9 +256,9 @@ func validateSchedulingInterval(interval string) error {
 func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 	req *replication.EnableVolumeReplicationRequest,
 ) (*replication.EnableVolumeReplicationResponse, error) {
-	volumeID := csicommon.GetIDFromReplication(req)
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	reqID := csicommon.GetIDFromReplication(req)
+	if reqID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty ID in request")
 	}
 	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
@@ -271,24 +271,23 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 		return nil, err
 	}
 
-	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	if acquired := rs.VolumeLocks.TryAcquire(reqID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, reqID)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, reqID)
 	}
-	defer rs.VolumeLocks.Release(volumeID)
+	defer rs.VolumeLocks.Release(reqID)
 
 	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
-	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, reqID, req.GetReplicationSource())
 	if err != nil {
+		log.ErrorLog(ctx, "failed to get mirror source with id %q: %v", reqID, err)
+
 		return nil, getGRPCError(err)
 	}
-	mirror, err := rbdVol.ToMirror()
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	defer destoryVolumes(ctx, volumes)
 
 	// extract the mirroring mode
 	mirroringMode, err := getMirroringMode(ctx, req.GetParameters())
@@ -308,17 +307,28 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if info.GetState() != librbd.MirrorImageEnabled.String() {
-		err = rbdVol.HandleParentImageExistence(ctx, flattenMode)
-		if err != nil {
-			log.ErrorLog(ctx, err.Error())
+		if len(volumes) > 0 {
+			for _, rbdVol := range volumes {
+				err = rbdVol.HandleParentImageExistence(ctx, flattenMode)
+				if err != nil {
+					err = fmt.Errorf("failed to handle parent image for volume group %q: %w", mirror, err)
+					return nil, getGRPCError(err)
+				}
+				err = mirror.EnableMirroring(ctx, mirroringMode)
+				if err != nil {
+					log.ErrorLog(ctx, err.Error())
 
-			return nil, getGRPCError(err)
-		}
-		err = mirror.EnableMirroring(ctx, mirroringMode)
-		if err != nil {
-			log.ErrorLog(ctx, err.Error())
+					return nil, status.Error(codes.Internal, err.Error())
+				}
+			}
+		} else {
+			// enable mirroring for an empty volume group
+			err = mirror.EnableMirroring(ctx, mirroringMode)
+			if err != nil {
+				log.ErrorLog(ctx, err.Error())
 
-			return nil, status.Error(codes.Internal, err.Error())
+				return nil, status.Error(codes.Internal, err.Error())
+			}
 		}
 	}
 
@@ -331,9 +341,9 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	req *replication.DisableVolumeReplicationRequest,
 ) (*replication.DisableVolumeReplicationResponse, error) {
-	volumeID := csicommon.GetIDFromReplication(req)
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	reqID := csicommon.GetIDFromReplication(req)
+	if reqID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty ID in request")
 	}
 	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
@@ -341,24 +351,23 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	}
 	defer cr.DeleteCredentials()
 
-	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	if acquired := rs.VolumeLocks.TryAcquire(reqID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, reqID)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, reqID)
 	}
-	defer rs.VolumeLocks.Release(volumeID)
+	defer rs.VolumeLocks.Release(reqID)
 
 	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
-	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, reqID, req.GetReplicationSource())
 	if err != nil {
+		log.ErrorLog(ctx, "failed to get mirror source with id %q: %v", reqID, err)
+
 		return nil, getGRPCError(err)
 	}
-	mirror, err := rbdVol.ToMirror()
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	defer destoryVolumes(ctx, volumes)
 
 	// extract the force option
 	force, err := getForceOption(ctx, req.GetParameters())
@@ -377,7 +386,7 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 	case librbd.MirrorImageDisabled.String():
 	// image mirroring is still disabling
 	case librbd.MirrorImageDisabling.String():
-		return nil, status.Errorf(codes.Aborted, "%s is in disabling state", volumeID)
+		return nil, status.Errorf(codes.Aborted, "%s is in disabling state", reqID)
 	case librbd.MirrorImageEnabled.String():
 		err = corerbd.DisableVolumeReplication(mirror, ctx, info.IsPrimary(), force)
 		if err != nil {
@@ -399,9 +408,9 @@ func (rs *ReplicationServer) DisableVolumeReplication(ctx context.Context,
 func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	req *replication.PromoteVolumeRequest,
 ) (*replication.PromoteVolumeResponse, error) {
-	volumeID := csicommon.GetIDFromReplication(req)
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	reqID := csicommon.GetIDFromReplication(req)
+	if reqID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty ID in request")
 	}
 	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
@@ -409,24 +418,23 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 	}
 	defer cr.DeleteCredentials()
 
-	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	if acquired := rs.VolumeLocks.TryAcquire(reqID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, reqID)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, reqID)
 	}
-	defer rs.VolumeLocks.Release(volumeID)
+	defer rs.VolumeLocks.Release(reqID)
 
 	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
-	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, reqID, req.GetReplicationSource())
 	if err != nil {
+		log.ErrorLog(ctx, "failed to get mirror source with id %q: %v", reqID, err)
+
 		return nil, getGRPCError(err)
 	}
-	mirror, err := rbdVol.ToMirror()
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	defer destoryVolumes(ctx, volumes)
 
 	info, err := mirror.GetMirroringInfo(ctx)
 	if err != nil {
@@ -439,7 +447,7 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"mirroring is not enabled on %s, image is in %s Mode",
-			volumeID,
+			reqID,
 			info.GetState())
 	}
 
@@ -476,10 +484,10 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 		}
 		log.DebugLog(
 			ctx,
-			"Added scheduling at interval %s, start time %s for volume %s",
+			"Added scheduling at interval %s, start time %s for Id %s",
 			interval,
 			startTime,
-			rbdVol)
+			reqID)
 	}
 
 	return &replication.PromoteVolumeResponse{}, nil
@@ -492,9 +500,9 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	req *replication.DemoteVolumeRequest,
 ) (*replication.DemoteVolumeResponse, error) {
-	volumeID := csicommon.GetIDFromReplication(req)
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	reqID := csicommon.GetIDFromReplication(req)
+	if reqID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty ID in request")
 	}
 	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
@@ -502,31 +510,23 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	}
 	defer cr.DeleteCredentials()
 
-	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	if acquired := rs.VolumeLocks.TryAcquire(reqID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, reqID)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, reqID)
 	}
-	defer rs.VolumeLocks.Release(volumeID)
+	defer rs.VolumeLocks.Release(reqID)
 
 	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
-	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, reqID, req.GetReplicationSource())
 	if err != nil {
+		log.ErrorLog(ctx, "failed to get mirror source with id %q: %v", reqID, err)
+
 		return nil, getGRPCError(err)
 	}
-	mirror, err := rbdVol.ToMirror()
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	creationTime, err := rbdVol.GetCreationTime(ctx)
-	if err != nil {
-		log.ErrorLog(ctx, err.Error())
-
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	defer destoryVolumes(ctx, volumes)
 
 	info, err := mirror.GetMirroringInfo(ctx)
 	if err != nil {
@@ -539,24 +539,33 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"mirroring is not enabled on %s, image is in %s Mode",
-			volumeID,
+			reqID,
 			info.GetState())
 	}
 
 	// demote image to secondary
 	if info.IsPrimary() {
-		// store the image creation time for resync
-		_, err = rbdVol.GetMetadata(imageCreationTimeKey)
-		if err != nil && errors.Is(err, librbd.ErrNotFound) {
-			log.DebugLog(ctx, "setting image creation time %s for %s", creationTime, rbdVol)
-			err = rbdVol.SetMetadata(imageCreationTimeKey, timestampToString(creationTime))
-		}
-		if err != nil {
-			log.ErrorLog(ctx, err.Error())
+		for _, vol := range volumes {
+			// store the image creation time for resync
+			creationTime, cErr := vol.GetCreationTime(ctx)
+			if cErr != nil {
+				log.ErrorLog(ctx, cErr.Error())
 
-			return nil, status.Error(codes.Internal, err.Error())
-		}
+				return nil, status.Error(codes.Internal, cErr.Error())
+			}
 
+			// store the image creation time for resync
+			_, err = vol.GetMetadata(imageCreationTimeKey)
+			if err != nil && errors.Is(err, librbd.ErrNotFound) {
+				log.DebugLog(ctx, "setting image creation time %s for %s", creationTime, vol)
+				err = vol.SetMetadata(imageCreationTimeKey, timestampToString(creationTime))
+			}
+			if err != nil {
+				log.ErrorLog(ctx, err.Error())
+
+				return nil, status.Error(codes.Internal, err.Error())
+			}
+		}
 		err = mirror.Demote(ctx)
 		if err != nil {
 			log.ErrorLog(ctx, err.Error())
@@ -603,9 +612,9 @@ func checkRemoteSiteStatus(ctx context.Context, mirrorStatus []types.SiteStatus)
 func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	req *replication.ResyncVolumeRequest,
 ) (*replication.ResyncVolumeResponse, error) {
-	volumeID := csicommon.GetIDFromReplication(req)
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	reqID := csicommon.GetIDFromReplication(req)
+	if reqID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty ID in request")
 	}
 	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
@@ -613,23 +622,23 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 	}
 	defer cr.DeleteCredentials()
 
-	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	if acquired := rs.VolumeLocks.TryAcquire(reqID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, reqID)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, reqID)
 	}
-	defer rs.VolumeLocks.Release(volumeID)
+	defer rs.VolumeLocks.Release(reqID)
+
 	mgr := rbd.NewManager(rs.driverInstance, req.GetParameters(), req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
-	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, reqID, req.GetReplicationSource())
 	if err != nil {
+		log.ErrorLog(ctx, "failed to get mirror source with id %q: %v", reqID, err)
+
 		return nil, getGRPCError(err)
 	}
-	mirror, err := rbdVol.ToMirror()
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	defer destoryVolumes(ctx, volumes)
 
 	info, err := mirror.GetMirroringInfo(ctx)
 	if err != nil {
@@ -694,35 +703,40 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		ready = checkRemoteSiteStatus(ctx, sts.GetAllSitesStatus())
 	}
 
-	creationTime, err := rbdVol.GetCreationTime(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get image info for %s: %s", rbdVol, err.Error())
-	}
-
-	// image creation time is stored in the image metadata. it looks like
-	// `"seconds:1692879841 nanos:631526669"`
-	// If the image gets resynced the local image creation time will be
-	// lost, if the keys is not present in the image metadata then we can
-	// assume that the image is already resynced.
-	savedImageTime, err := rbdVol.GetMetadata(imageCreationTimeKey)
-	if err != nil && !errors.Is(err, librbd.ErrNotFound) {
-		return nil, status.Errorf(codes.Internal,
-			"failed to get %s key from image metadata for %s: %s",
-			imageCreationTimeKey,
-			rbdVol,
-			err.Error())
-	}
-
-	if savedImageTime != "" {
-		st, sErr := timestampFromString(savedImageTime)
-		if sErr != nil {
-			return nil, status.Errorf(codes.Internal, "failed to parse image creation time: %s", sErr.Error())
+	for _, vol := range volumes {
+		creationTime, tErr := vol.GetCreationTime(ctx)
+		if tErr != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get image info for %s: %s", vol, tErr.Error())
 		}
-		log.DebugLog(ctx, "image %s, savedImageTime=%v, currentImageTime=%v", rbdVol, st, creationTime)
-		if req.GetForce() && st.Equal(*creationTime) {
-			err = mirror.Resync(ctx)
-			if err != nil {
-				return nil, getGRPCError(err)
+
+		// image creation time is stored in the image metadata. it looks like
+		// `"seconds:1692879841 nanos:631526669"`
+		// If the image gets resynced the local image creation time will be
+		// lost, if the keys is not present in the image metadata then we can
+		// assume that the image is already resynced.
+		var savedImageTime string
+		savedImageTime, err = vol.GetMetadata(imageCreationTimeKey)
+		if err != nil && !errors.Is(err, librbd.ErrNotFound) {
+			return nil, status.Errorf(codes.Internal,
+				"failed to get %s key from image metadata for %s: %s",
+				imageCreationTimeKey,
+				vol,
+				err.Error())
+		}
+
+		if savedImageTime != "" {
+			st, sErr := timestampFromString(savedImageTime)
+			if sErr != nil {
+				return nil, status.Errorf(codes.Internal, "failed to parse image creation time: %s", sErr.Error())
+			}
+			log.DebugLog(ctx, "image %s, savedImageTime=%v, currentImageTime=%v", vol, st, creationTime)
+			if req.GetForce() && st.Equal(*creationTime) {
+				err = mirror.Resync(ctx)
+				if err != nil {
+					return nil, getGRPCError(err)
+				}
+				// Break the loop as we need to issue resync only once for the image or for the group.
+				break
 			}
 		}
 	}
@@ -734,9 +748,12 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 		}
 	}
 
-	err = rbdVol.RepairResyncedImageID(ctx, ready)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to resync Image ID: %s", err.Error())
+	// update imageID for all the volumes
+	for _, vol := range volumes {
+		err = vol.RepairResyncedImageID(ctx, ready)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to resync Image ID: %s", err.Error())
+		}
 	}
 
 	resp := &replication.ResyncVolumeResponse{
@@ -811,9 +828,9 @@ func getGRPCError(err error) error {
 func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	req *replication.GetVolumeReplicationInfoRequest,
 ) (*replication.GetVolumeReplicationInfoResponse, error) {
-	volumeID := csicommon.GetIDFromReplication(req)
-	if volumeID == "" {
-		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
+	reqID := csicommon.GetIDFromReplication(req)
+	if reqID == "" {
+		return nil, status.Error(codes.InvalidArgument, "empty ID in request")
 	}
 	cr, err := util.NewUserCredentials(req.GetSecrets())
 	if err != nil {
@@ -823,36 +840,23 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(ctx context.Context,
 	}
 	defer cr.DeleteCredentials()
 
-	if acquired := rs.VolumeLocks.TryAcquire(volumeID); !acquired {
-		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, volumeID)
+	if acquired := rs.VolumeLocks.TryAcquire(reqID); !acquired {
+		log.ErrorLog(ctx, util.VolumeOperationAlreadyExistsFmt, reqID)
 
-		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volumeID)
+		return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, reqID)
 	}
-	defer rs.VolumeLocks.Release(volumeID)
+	defer rs.VolumeLocks.Release(reqID)
+
 	mgr := rbd.NewManager(rs.driverInstance, nil, req.GetSecrets())
 	defer mgr.Destroy(ctx)
 
-	rbdVol, err := mgr.GetVolumeByID(ctx, volumeID)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, reqID, req.GetReplicationSource())
 	if err != nil {
-		log.ErrorLog(ctx, "failed to get volume with id %q: %v", volumeID, err)
+		log.ErrorLog(ctx, "failed to get mirror source with id %q: %v", reqID, err)
 
-		switch {
-		case errors.Is(err, rbderrors.ErrImageNotFound):
-			err = status.Error(codes.NotFound, err.Error())
-		case errors.Is(err, util.ErrPoolNotFound):
-			err = status.Error(codes.NotFound, err.Error())
-		default:
-			err = status.Error(codes.Internal, err.Error())
-		}
-
-		return nil, err
+		return nil, getGRPCError(err)
 	}
-	mirror, err := rbdVol.ToMirror()
-	if err != nil {
-		log.ErrorLog(ctx, "failed to convert volume %q to mirror type: %v", rbdVol, err)
-
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	defer destoryVolumes(ctx, volumes)
 
 	info, err := mirror.GetMirroringInfo(ctx)
 	if err != nil {
@@ -988,4 +992,11 @@ func checkVolumeResyncStatus(ctx context.Context, localStatus types.SiteStatus) 
 	}
 
 	return nil
+}
+
+// destoryVolumes destroys the volume connections.
+func destoryVolumes(ctx context.Context, volumes []types.Volume) {
+	for _, vol := range volumes {
+		vol.Destroy(ctx)
+	}
 }

--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -312,23 +312,16 @@ func (rs *ReplicationServer) EnableVolumeReplication(ctx context.Context,
 				err = rbdVol.HandleParentImageExistence(ctx, flattenMode)
 				if err != nil {
 					err = fmt.Errorf("failed to handle parent image for volume group %q: %w", mirror, err)
+
 					return nil, getGRPCError(err)
 				}
-				err = mirror.EnableMirroring(ctx, mirroringMode)
-				if err != nil {
-					log.ErrorLog(ctx, err.Error())
-
-					return nil, status.Error(codes.Internal, err.Error())
-				}
 			}
-		} else {
-			// enable mirroring for an empty volume group
-			err = mirror.EnableMirroring(ctx, mirroringMode)
-			if err != nil {
-				log.ErrorLog(ctx, err.Error())
+		}
+		err = mirror.EnableMirroring(ctx, mirroringMode)
+		if err != nil {
+			log.ErrorLog(ctx, err.Error())
 
-				return nil, status.Error(codes.Internal, err.Error())
-			}
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
 
@@ -451,6 +444,22 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 			info.GetState())
 	}
 
+	globalMirroringStatus, err := mirror.GetGlobalMirroringStatus(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	localStatus, err := globalMirroringStatus.GetLocalSiteStatus()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if !info.IsPrimary() && localStatus.IsUP() &&
+		(localStatus.GetState() != librbd.MirrorGroupStatusStateUnknown.String() &&
+			localStatus.GetState() != librbd.MirrorGroupStatusStateReplaying.String()) {
+		return nil, status.Errorf(codes.Internal, "group %s is not in secondary state before promotion", reqID)
+	}
+
 	// promote secondary to primary
 	if !info.IsPrimary() {
 		if req.GetForce() {
@@ -543,8 +552,18 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 			info.GetState())
 	}
 
+	globalMirroringStatus, err := mirror.GetGlobalMirroringStatus(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	localStatus, err := globalMirroringStatus.GetLocalSiteStatus()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	// demote image to secondary
-	if info.IsPrimary() {
+	if info.IsPrimary() && localStatus.IsUP() && localStatus.GetState() == librbd.MirrorGroupStatusStateStopped.String() {
 		for _, vol := range volumes {
 			// store the image creation time for resync
 			creationTime, cErr := vol.GetCreationTime(ctx)
@@ -572,6 +591,17 @@ func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+	}
+
+	info, err = mirror.GetMirroringInfo(ctx)
+	if err != nil {
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if info.IsPrimary() {
+		return nil, status.Error(codes.Internal, "volume/volume group has not been demoted, yet!")
 	}
 
 	return &replication.DemoteVolumeResponse{}, nil

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -101,11 +101,7 @@ func (vs *VolumeGroupServer) CreateVolumeGroup(
 
 	// resolve all volumes
 	volumes := make([]types.Volume, 0)
-	defer func() {
-		for _, vol := range volumes {
-			vol.Destroy(ctx)
-		}
-	}()
+	defer destoryVolumes(ctx, volumes)
 	for i, id := range req.GetVolumeIds() {
 		vol, err := mgr.GetVolumeByID(ctx, id)
 		if err != nil {
@@ -442,11 +438,7 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 
 	// resolve all volumes
 	volumes := make([]types.Volume, len(toAdd))
-	defer func() {
-		for _, vol := range volumes {
-			vol.Destroy(ctx)
-		}
-	}()
+	defer destoryVolumes(ctx, volumes)
 	for i, id := range toAdd {
 		var vol types.Volume
 		vol, err = mgr.GetVolumeByID(ctx, id)

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
+	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
 	"google.golang.org/grpc"
@@ -315,14 +316,6 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 
 	// verify that the volume group is empty, if the group is primary
 	if vgrMirrorInfo.IsPrimary() {
-		volumes, err = vg.ListVolumes(ctx)
-		if err != nil {
-			return nil, status.Errorf(
-				codes.NotFound,
-				"could not list volumes for volume group %q: %s",
-				req.GetVolumeGroupId(),
-				err.Error())
-		}
 		log.DebugLog(ctx, "VolumeGroup %q contains %d volumes", req.GetVolumeGroupId(), len(volumes))
 		if len(volumes) != 0 {
 			return nil, status.Errorf(
@@ -384,6 +377,8 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 //
 // Also, MODIFY_VOLUME_GROUP_MEMBERSHIP does not exist, it is called
 // MODIFY_VOLUME_GROUP instead.
+//
+//nolint:gocyclo,cyclop,gocognit // reduce complexity
 func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	ctx context.Context,
 	req *volumegroup.ModifyVolumeGroupMembershipRequest,
@@ -394,9 +389,19 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	// resolve the volume group
 	vg, err := mgr.GetVolumeGroupByID(ctx, req.GetVolumeGroupId())
 	if err != nil {
+		if errors.Is(err, rbderrors.ErrGroupNotFound) {
+			log.ErrorLog(ctx, "VolumeGroup %q doesn't exists", req.GetVolumeGroupId())
+
+			return nil, status.Errorf(
+				codes.NotFound,
+				"could not find volume group %q: %s",
+				req.GetVolumeGroupId(),
+				err.Error())
+		}
+
 		return nil, status.Errorf(
-			codes.NotFound,
-			"could not find volume group %q: %s",
+			codes.Internal,
+			"could not fetch volume group %q: %s",
 			req.GetVolumeGroupId(),
 			err.Error())
 	}
@@ -421,10 +426,55 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// Skip modification of group if it's secondary
-	if !vgrMirrorInfo.IsPrimary() {
-		log.DebugLog(ctx, "skipping modification of group, as it is in secondary state")
-		return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
+	// If the mirroring is not enabled and we are modifying the group, that means
+	// we are doing a cleanup and we shouldn't be checking for mirror status
+	isMirroringEnabled := false
+	if vgrMirrorInfo.GetState() == librbd.MirrorImageEnabled.String() {
+		isMirroringEnabled = true
+		sts, rErr := mirror.GetGlobalMirroringStatus(ctx)
+		if rErr != nil {
+			return nil, status.Error(codes.Internal, rErr.Error())
+		}
+
+		localStatus, rErr := sts.GetLocalSiteStatus()
+		if rErr != nil {
+			return nil, status.Error(codes.Internal, rErr.Error())
+		}
+
+		log.DebugLog(ctx, "local status is %v and local state is %v", localStatus.IsUP(), localStatus.GetState())
+		if !vgrMirrorInfo.IsPrimary() ||
+			(localStatus.IsUP() && localStatus.GetState() != librbd.MirrorGroupStatusStateStopped.String()) {
+			log.DebugLog(ctx, "skipping modification of group, as it is in secondary/promoting state")
+
+			return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
+		}
+
+		remoteSiteStatus, err := sts.GetRemoteSiteStatus(ctx)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		if (localStatus.IsUP() && localStatus.GetState() == librbd.MirrorGroupStatusStateStopped.String()) &&
+			(remoteSiteStatus.IsUP() && remoteSiteStatus.GetState() == librbd.MirrorGroupStatusStateStopped.String()) {
+			err = errors.New("both the groups are in primary state, resync needs to happen before modifying the group")
+
+			return nil, status.Errorf(
+				codes.Internal,
+				"failed to modify group %q, %v",
+				vg,
+				err)
+		}
+	}
+
+	if vgrMirrorInfo.GetState() == librbd.MirrorGroupEnabling.String() ||
+		vgrMirrorInfo.GetState() == librbd.MirrorGroupDisabling.String() {
+		err = errors.New("group is in either enabling/disabling mirror state")
+
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to modify group %q,there's an ongoing transaction on group: %v",
+			vg,
+			err)
 	}
 
 	beforeVolumes, err := vg.ListVolumes(ctx)
@@ -465,6 +515,26 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	for _, id := range afterIDs {
 		if _, ok := beforeIDs[id]; !ok {
 			toAdd = append(toAdd, id)
+		}
+	}
+
+	// Skip modification if there is no change to volumes list that are part of group
+	if len(toRemove) == 0 && len(toAdd) == 0 {
+		return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
+	}
+
+	// Disable mirroring before modifying the volume group
+	if isMirroringEnabled {
+		// extract the force option
+		force, err := getForceOption(ctx, req.GetParameters())
+		if err != nil {
+			return nil, err
+		}
+		err = rbd.DisableVolumeReplication(mirror, ctx, vgrMirrorInfo.IsPrimary(), force)
+		if err != nil {
+			log.ErrorLog(ctx, "failed to disable mirroring before modifying volume group")
+
+			return nil, getGRPCError(err)
 		}
 	}
 
@@ -525,6 +595,19 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 				vg,
 				err)
 		}
+	}
+
+	// Enable mirroring after modification of volume group
+	// extract the mirroring mode
+	mirroringMode, err := getMirroringMode(ctx, req.GetParameters())
+	if err != nil {
+		return nil, err
+	}
+	err = mirror.EnableMirroring(ctx, mirroringMode)
+	if err != nil {
+		log.ErrorLog(ctx, "failed to enable mirroring after modifying volume group")
+
+		return nil, getGRPCError(err)
 	}
 
 	csiVG, err := vg.ToCSI(ctx)

--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util/log"
 
+	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -292,23 +293,43 @@ func (vs *VolumeGroupServer) DeleteVolumeGroup(
 
 	log.DebugLog(ctx, "VolumeGroup %q has been found", req.GetVolumeGroupId())
 
-	// verify that the volume group is empty
-	volumes, err := vg.ListVolumes(ctx)
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, req.GetVolumeGroupId(), &replication.ReplicationSource{
+		Type: &replication.ReplicationSource_Volumegroup{
+			Volumegroup: &replication.ReplicationSource_VolumeGroupSource{
+				VolumeGroupId: req.GetVolumeGroupId(),
+			},
+		},
+	})
+	defer destoryVolumes(ctx, volumes)
+
 	if err != nil {
-		return nil, status.Errorf(
-			codes.NotFound,
-			"could not list volumes for voluem group %q: %s",
-			req.GetVolumeGroupId(),
-			err.Error())
+		return nil, getGRPCError(err)
 	}
 
-	log.DebugLog(ctx, "VolumeGroup %q contains %d volumes", req.GetVolumeGroupId(), len(volumes))
+	vgrMirrorInfo, err := mirror.GetMirroringInfo(ctx)
+	if err != nil {
+		log.ErrorLog(ctx, err.Error())
 
-	if len(volumes) != 0 {
-		return nil, status.Errorf(
-			codes.FailedPrecondition,
-			"rejecting to delete non-empty volume group %q",
-			req.GetVolumeGroupId())
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	// verify that the volume group is empty, if the group is primary
+	if vgrMirrorInfo.IsPrimary() {
+		volumes, err = vg.ListVolumes(ctx)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.NotFound,
+				"could not list volumes for volume group %q: %s",
+				req.GetVolumeGroupId(),
+				err.Error())
+		}
+		log.DebugLog(ctx, "VolumeGroup %q contains %d volumes", req.GetVolumeGroupId(), len(volumes))
+		if len(volumes) != 0 {
+			return nil, status.Errorf(
+				codes.FailedPrecondition,
+				"rejecting to delete non-empty volume group %q",
+				req.GetVolumeGroupId())
+		}
 	}
 
 	// delete the volume group
@@ -381,6 +402,31 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	}
 	defer vg.Destroy(ctx)
 
+	volumes, mirror, err := mgr.GetMirrorSource(ctx, req.GetVolumeGroupId(), &replication.ReplicationSource{
+		Type: &replication.ReplicationSource_Volumegroup{
+			Volumegroup: &replication.ReplicationSource_VolumeGroupSource{
+				VolumeGroupId: req.GetVolumeGroupId(),
+			},
+		},
+	})
+	defer destoryVolumes(ctx, volumes)
+	if err != nil {
+		return nil, getGRPCError(err)
+	}
+
+	vgrMirrorInfo, err := mirror.GetMirroringInfo(ctx)
+	if err != nil {
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	// Skip modification of group if it's secondary
+	if !vgrMirrorInfo.IsPrimary() {
+		log.DebugLog(ctx, "skipping modification of group, as it is in secondary state")
+		return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
+	}
+
 	beforeVolumes, err := vg.ListVolumes(ctx)
 	if err != nil {
 		return nil, status.Errorf(
@@ -437,8 +483,8 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	}
 
 	// resolve all volumes
-	volumes := make([]types.Volume, len(toAdd))
-	defer destoryVolumes(ctx, volumes)
+	newVolumes := make([]types.Volume, len(toAdd))
+	defer destoryVolumes(ctx, newVolumes)
 	for i, id := range toAdd {
 		var vol types.Volume
 		vol, err = mgr.GetVolumeByID(ctx, id)
@@ -449,7 +495,7 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 				id,
 				err)
 		}
-		volumes[i] = vol
+		newVolumes[i] = vol
 	}
 
 	// extract the flatten mode
@@ -459,7 +505,7 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	}
 	// Flatten the image if the flatten mode is set to FlattenModeForce
 	// before adding it to the volume group.
-	for _, vol := range volumes {
+	for _, vol := range newVolumes {
 		err = vol.HandleParentImageExistence(ctx, flattenMode)
 		if err != nil {
 			err = fmt.Errorf("failed to handle parent image for volume group %q: %w", vg, err)
@@ -469,7 +515,7 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	}
 
 	// add the new volumes to the group
-	for _, vol := range volumes {
+	for _, vol := range newVolumes {
 		err = vg.AddVolume(ctx, vol)
 		if err != nil {
 			return nil, status.Errorf(

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -24,6 +24,7 @@ import (
 
 	csicommon "github.com/ceph/ceph-csi/internal/csi-common"
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
 	"github.com/ceph/ceph-csi/internal/util"
 	"github.com/ceph/ceph-csi/internal/util/k8s"
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -963,6 +964,9 @@ func (cs *ControllerServer) DeleteVolume(
 		return nil, status.Error(codes.InvalidArgument, "empty volume ID in request")
 	}
 
+	mgr := NewManager(cs.Driver.GetInstanceID(), nil, req.GetSecrets())
+	defer mgr.Destroy(ctx)
+
 	cr, err := util.NewUserCredentialsWithMigration(req.GetSecrets())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -1017,12 +1021,12 @@ func (cs *ControllerServer) DeleteVolume(
 	}
 	defer cs.VolumeLocks.Release(rbdVol.RequestName)
 
-	return cleanupRBDImage(ctx, rbdVol, cr)
+	return cleanupRBDImage(ctx, rbdVol, cr, mgr)
 }
 
 // cleanupRBDImage removes the rbd image and OMAP metadata associated with it.
-func cleanupRBDImage(ctx context.Context,
-	rbdVol *rbdVolume, cr *util.Credentials,
+func cleanupRBDImage(ctx context.Context, rbdVol *rbdVolume,
+	cr *util.Credentials, mgr types.Manager,
 ) (*csi.DeleteVolumeResponse, error) {
 	info, err := rbdVol.GetMirroringInfo(ctx)
 	if err != nil {
@@ -1080,6 +1084,21 @@ func cleanupRBDImage(ctx context.Context,
 		log.ErrorLog(ctx, "rbd %s is still being used", rbdVol)
 
 		return nil, status.Errorf(codes.Aborted, "rbd %s is still being used", rbdVol.RbdImageName)
+	}
+
+	// check if image is part of a group
+	groupId, err := rbdVol.GetVolumeGroupID(ctx, mgr)
+	if err != nil && !errors.Is(err, rbderrors.ErrGroupNotFound) {
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if groupId != "" {
+		err = fmt.Errorf("image %q is a part of volume group %q", rbdVol, groupId)
+		log.ErrorLog(ctx, err.Error())
+
+		return nil, status.Error(codes.Aborted, err.Error())
 	}
 
 	// delete the temporary rbd image created as part of volume clone during

--- a/internal/rbd/errors/errors.go
+++ b/internal/rbd/errors/errors.go
@@ -72,4 +72,6 @@ var (
 	ErrGroupUnavailable = errors.New("group needs to be recreated")
 	// ErrStatusNotFound is returned when the image/group mirror status is not found.
 	ErrStatusNotFound = errors.New("rbd image/group status not found")
+	// ErrGroupInvalidArgument is returned when an invalid operation is attempted on the group.
+	ErrGroupInvalidArgument = errors.New("rbd group invalid arguments provided")
 )

--- a/internal/rbd/errors/errors.go
+++ b/internal/rbd/errors/errors.go
@@ -67,4 +67,9 @@ var (
 	ErrGroupNotConnected = fmt.Errorf("%w: RBD group is not connected", librados.ErrNotConnected)
 	// ErrGroupNotFound is returned when group is not found in the cluster on the given pool and/or namespace.
 	ErrGroupNotFound = fmt.Errorf("%w: RBD group not found", librbd.ErrNotFound)
+	// ErrGroupUnavailable is returned when the group needs to be recreated
+	// locally and may be corrected by retrying with a backoff.
+	ErrGroupUnavailable = errors.New("group needs to be recreated")
+	// ErrStatusNotFound is returned when the image/group mirror status is not found.
+	ErrStatusNotFound = errors.New("rbd image/group status not found")
 )

--- a/internal/rbd/group/group_mirror.go
+++ b/internal/rbd/group/group_mirror.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2025 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ceph/go-ceph/rados"
+	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/ceph/go-ceph/rbd/admin"
+
+	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
+	"github.com/ceph/ceph-csi/internal/rbd/types"
+	"github.com/ceph/ceph-csi/internal/util"
+	"github.com/ceph/ceph-csi/internal/util/log"
+)
+
+type volumeGroupMirror volumeGroup
+
+func (vgm *volumeGroupMirror) EnableMirroring(ctx context.Context, mode librbd.ImageMirrorMode) error {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.MirrorGroupEnable(ioctx, name, mode)
+	if err != nil {
+		return fmt.Errorf("failed to enable mirroring on volume group %q: %w", vgm, err)
+	}
+
+	log.DebugLog(ctx, "mirroring is enabled on the volume group %q", vgm)
+
+	return nil
+}
+
+func (vgm *volumeGroupMirror) DisableMirroring(ctx context.Context, force bool) error {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.MirrorGroupDisable(ioctx, name, force)
+	if err != nil && !errors.Is(err, rados.ErrNotFound) {
+		return fmt.Errorf("failed to disable mirroring on volume group %q: %w", vgm, err)
+	}
+
+	log.DebugLog(ctx, "mirroring is disabled on the volume group %q", vgm)
+
+	return nil
+}
+
+func (vgm *volumeGroupMirror) Promote(ctx context.Context, force bool) error {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.MirrorGroupPromote(ioctx, name, force)
+	if err != nil {
+		return fmt.Errorf("failed to promote volume group %q: %w", vgm, err)
+	}
+
+	log.DebugLog(ctx, "volume group %q has been promoted", vgm)
+
+	return nil
+}
+
+func (vgm *volumeGroupMirror) ForcePromote(ctx context.Context, cr *util.Credentials) error {
+	promoteArgs := []string{
+		"mirror", "group", "promote",
+		vgm.String(),
+		"--force",
+		"--id", cr.ID,
+		"-m", vgm.monitors,
+		"--keyfile=" + cr.KeyFile,
+	}
+	_, stderr, err := util.ExecCommandWithTimeout(
+		ctx,
+		// 2 minutes timeout as the Replication RPC timeout is 2.5 minutes.
+		2*time.Minute,
+		"rbd",
+		promoteArgs...,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to promote group %q with error: %w", vgm, err)
+	}
+
+	if stderr != "" {
+		return fmt.Errorf("failed to promote group %q with stderror: %s", vgm, stderr)
+	}
+
+	log.DebugLog(ctx, "volume group %q has been force promoted", vgm)
+
+	return nil
+}
+
+func (vgm *volumeGroupMirror) Demote(ctx context.Context) error {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.MirrorGroupDemote(ioctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to demote volume group %q: %w", vgm, err)
+	}
+
+	log.DebugLog(ctx, "volume group %q has been demoted", vgm)
+
+	return nil
+}
+
+func (vgm *volumeGroupMirror) Resync(ctx context.Context) error {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = librbd.MirrorGroupResync(ioctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to resync volume group %q: %w", vgm, err)
+	}
+
+	log.DebugLog(ctx, "issued resync on volume group %q", vgm)
+	// If we issued a resync, return a non-final error as image needs to be recreated
+	// locally. Caller retries till RBD syncs an initial version of the image to
+	// report its status in the resync request.
+	return fmt.Errorf("%w: awaiting initial resync due to split brain", rbderrors.ErrGroupUnavailable)
+}
+
+func (vgm *volumeGroupMirror) GetMirroringInfo(ctx context.Context) (types.MirrorInfo, error) {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := librbd.GetMirrorGroupInfo(ioctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volume group mirroring info %q: %w", vgm, err)
+	}
+
+	gi := groupInfo(*info)
+
+	return gi, nil
+}
+
+func (vgm *volumeGroupMirror) GetGlobalMirroringStatus(ctx context.Context) (types.GlobalStatus, error) {
+	name, err := vgm.GetName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ioctx, err := vgm.GetIOContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	statusInfo, err := librbd.GetGlobalMirrorGroupStatus(ioctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get volume group mirroring status %q: %w", vgm, err)
+	}
+
+	gms := globalMirrorGroupStatus(statusInfo)
+
+	return &gms, nil
+}
+
+func (vgm *volumeGroupMirror) AddSnapshotScheduling(interval admin.Interval, startTime admin.StartTime) error {
+	ls := admin.NewLevelSpec(vgm.pool, vgm.namespace, "")
+	ra, err := vgm.conn.GetRBDAdmin()
+	if err != nil {
+		return err
+	}
+	adminConn := ra.MirrorSnashotSchedule()
+	err = adminConn.Add(ls, interval, startTime)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// groupInfo is a wrapper around librbd.MirrorGroupInfo that contains the
+// group mirror info.
+type groupInfo librbd.MirrorGroupInfo
+
+func (info groupInfo) GetState() string {
+	return info.State.String()
+}
+
+func (info groupInfo) IsPrimary() bool {
+	return info.Primary
+}
+
+// globalMirrorGroupStatus is a wrapper around librbd.GlobalGroupMirrorImageStatus that contains the
+// global mirror group status.
+type globalMirrorGroupStatus librbd.GlobalMirrorGroupStatus
+
+func (status *globalMirrorGroupStatus) GetState() string {
+	return status.Info.State.String()
+}
+
+func (status *globalMirrorGroupStatus) IsPrimary() bool {
+	return status.Info.Primary
+}
+
+func (status *globalMirrorGroupStatus) GetLocalSiteStatus() (types.SiteStatus, error) {
+	mstatus := librbd.GlobalMirrorGroupStatus(*status)
+	s, err := mstatus.LocalStatus()
+	if err != nil {
+		err = fmt.Errorf("failed to get local site status: %w", err)
+	}
+
+	smgs := siteMirrorGroupStatus(s)
+
+	return &smgs, err
+}
+
+func (status *globalMirrorGroupStatus) GetAllSitesStatus() []types.SiteStatus {
+	var siteStatuses []types.SiteStatus
+	for _, ss := range status.SiteStatuses {
+		smgs := siteMirrorGroupStatus(ss)
+		siteStatuses = append(siteStatuses, &smgs)
+	}
+
+	return siteStatuses
+}
+
+// RemoteStatus returns one SiteMirrorGroupStatus item from the SiteStatuses
+// slice that corresponds to the remote site's status. If the remote status
+// is not found than the error ErrStatusNotFound will be returned.
+func (status *globalMirrorGroupStatus) GetRemoteSiteStatus(ctx context.Context) (types.SiteStatus, error) {
+	var (
+		ss  librbd.SiteMirrorGroupStatus
+		err error = rbderrors.ErrStatusNotFound
+	)
+
+	for i := range status.SiteStatuses {
+		log.DebugLog(
+			ctx,
+			"Site status of MirrorUUID: %s, state: %s, description: %s, lastUpdate: %v, up: %t",
+			status.SiteStatuses[i].MirrorUUID,
+			status.SiteStatuses[i].State,
+			status.SiteStatuses[i].Description,
+			status.SiteStatuses[i].LastUpdate,
+			status.SiteStatuses[i].Up)
+
+		if status.SiteStatuses[i].MirrorUUID != "" {
+			ss = status.SiteStatuses[i]
+			err = nil
+
+			break
+		}
+	}
+
+	grmss := siteMirrorGroupStatus(ss)
+
+	return &grmss, err
+}
+
+// siteMirrorGroupStatus is a wrapper around librbd.SiteMirrorGroupStatus that contains the
+// site mirror group status.
+type siteMirrorGroupStatus librbd.SiteMirrorGroupStatus
+
+func (status *siteMirrorGroupStatus) GetMirrorUUID() string {
+	return status.MirrorUUID
+}
+
+func (status *siteMirrorGroupStatus) GetState() string {
+	return status.State.String()
+}
+
+func (status *siteMirrorGroupStatus) GetDescription() string {
+	return status.Description
+}
+
+func (status *siteMirrorGroupStatus) IsUP() bool {
+	return status.Up
+}
+
+func (status *siteMirrorGroupStatus) GetLastUpdate() time.Time {
+	// convert the last update time to UTC
+	return time.Unix(status.LastUpdate, 0).UTC()
+}

--- a/internal/rbd/group/util_test.go
+++ b/internal/rbd/group/util_test.go
@@ -47,7 +47,7 @@ func Test_shouldRetryVolumeGroupGeneration(t *testing.T) {
 			want: true, // Known error, continue searching
 		},
 		{
-			name: "ErrRBDGroupNotFound (continue searching)",
+			name: "ErrGroupNotFound (continue searching)",
 			args: args{err: rbderrors.ErrGroupNotFound},
 			want: true, // Known error, continue searching
 		},

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -25,6 +25,8 @@ import (
 	librbd "github.com/ceph/go-ceph/rbd"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	"github.com/ceph/ceph-csi/internal/rbd/types"
@@ -187,6 +189,56 @@ func (vg *volumeGroup) Delete(ctx context.Context) error {
 
 	ioctx, err := vg.GetIOContext(ctx)
 	if err != nil {
+		return err
+	}
+
+	mirror, err := vg.ToMirror()
+	if err != nil {
+		return fmt.Errorf("failed to convert volume group %q to mirror: %w", vg, err)
+	}
+
+	vgrMirrorInfo, err := mirror.GetMirroringInfo(ctx)
+	if err != nil {
+		log.ErrorLog(ctx, err.Error())
+
+		return err
+	}
+
+	// Cleanup only omap data if the following condition is met
+	// Mirroring is enabled on the group
+	// Local group is secondary
+	// Local group is in up+replaying state
+	log.DebugLog(ctx, "volume group %v is in %v state and is primary %v", vg,
+		vgrMirrorInfo.GetState(), vgrMirrorInfo.IsPrimary())
+	if !vgrMirrorInfo.IsPrimary() && vgrMirrorInfo.GetState() == librbd.MirrorGroupEnabled.String() {
+		// If the group is in a secondary state and its up+replaying means its
+		// an healthy secondary and the group is primary somewhere in the
+		// remote cluster and the local group is getting replayed. Delete the
+		// OMAP data generated as we cannot delete the secondary group. When
+		// the group on the primary cluster gets deleted/mirroring disabled,
+		// the group on all the remote (secondary) clusters will get
+		// auto-deleted. This helps in garbage collecting the OMAP, VR, VGR,
+		// VGRC, PVC and PV objects after failback operation.
+		sts, rErr := mirror.GetGlobalMirroringStatus(ctx)
+		if rErr != nil {
+			return status.Error(codes.Internal, rErr.Error())
+		}
+		localStatus, rErr := sts.GetLocalSiteStatus()
+		if rErr != nil {
+			log.ErrorLog(ctx, "failed to get local status for volume group%s: %w", name, rErr)
+
+			return status.Error(codes.Internal, rErr.Error())
+		}
+		log.DebugLog(ctx, "local status is %v and local state is %v", localStatus.IsUP(), localStatus.GetState())
+		if localStatus.IsUP() && localStatus.GetState() == librbd.MirrorGroupStatusStateReplaying.String() {
+			return vg.commonVolumeGroup.Delete(ctx)
+		}
+		err = fmt.Errorf("%w: secondary group status is up=%t and state=%s",
+			rbderrors.ErrGroupInvalidArgument,
+			localStatus.IsUP(),
+			localStatus.GetState())
+		log.ErrorLog(ctx, err.Error())
+
 		return err
 	}
 

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -409,3 +409,9 @@ func (vg *volumeGroup) CreateSnapshots(
 
 	return snapshots, nil
 }
+
+func (vg *volumeGroup) ToMirror() (types.Mirror, error) {
+	vgm := volumeGroupMirror(*vg)
+
+	return &vgm, nil
+}

--- a/internal/rbd/manager.go
+++ b/internal/rbd/manager.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/csi-addons/spec/lib/go/replication"
+
 	"github.com/ceph/ceph-csi/internal/journal"
 	rbderrors "github.com/ceph/ceph-csi/internal/rbd/errors"
 	rbd_group "github.com/ceph/ceph-csi/internal/rbd/group"
@@ -724,4 +726,79 @@ func (mgr *rbdManager) VolumesInSameGroup(ctx context.Context, volumes []types.V
 	}
 
 	return true, nil
+}
+
+func (mgr *rbdManager) GetMirrorSource(ctx context.Context, reqID string,
+	rep *replication.ReplicationSource,
+) ([]types.Volume, types.Mirror, error) {
+	switch {
+	// Backward compatibility: if rep is nil, we assume that the sidecar is still old and
+	// setting only volumeId not the replication source.
+	case rep == nil || rep.GetVolume() != nil:
+		rbdVol, err := mgr.GetVolumeByID(ctx, reqID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get volume by id %q: %w", reqID, err)
+		}
+		defer func() {
+			if err != nil {
+				rbdVol.Destroy(ctx)
+			}
+		}()
+		var mir types.Mirror
+		mir, err = rbdVol.ToMirror()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert volume %s to mirror: %w", rbdVol, err)
+		}
+
+		return []types.Volume{rbdVol}, mir, nil
+	case rep.GetVolumegroup() != nil:
+		rbdGroup, err := mgr.GetVolumeGroupByID(ctx, reqID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get volume group by id %q: %w", reqID, err)
+		}
+		defer func() {
+			if err != nil {
+				rbdGroup.Destroy(ctx)
+			}
+		}()
+		var mir types.Mirror
+		mir, err = rbdGroup.ToMirror()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert volume group %s to mirror: %w", rbdGroup, err)
+		}
+		var vols []types.Volume
+		vols, err = rbdGroup.ListVolumes(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to list volumes in volume group %q: %w", rbdGroup, err)
+		}
+		// Get all the volume with connection and return it
+		volumes := make([]types.Volume, len(vols))
+		// Destroy connections if there is any error
+		defer func() {
+			if err != nil {
+				for _, vol := range vols {
+					vol.Destroy(ctx)
+				}
+			}
+		}()
+
+		for i, vol := range vols {
+			var id string
+			id, err = vol.GetID(ctx)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get id for volume %q in group %q: %w", vol, rbdGroup, err)
+			}
+			var v types.Volume
+			v, err = mgr.GetVolumeByID(ctx, id)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to get volume by id %q in group %q: %w", id, rbdGroup, err)
+			}
+			volumes[i] = v
+		}
+
+		return volumes, mir, nil
+
+	default:
+		return nil, nil, errors.New("replication source is not set")
+	}
 }

--- a/internal/rbd/mirror.go
+++ b/internal/rbd/mirror.go
@@ -273,11 +273,11 @@ func (status GlobalMirrorStatus) GetAllSitesStatus() []types.SiteStatus {
 
 // RemoteStatus returns one SiteMirrorImageStatus item from the SiteStatuses
 // slice that corresponds to the remote site's status. If the remote status
-// is not found than the error ErrNotExist will be returned.
+// is not found than the error ErrStatusNotFound will be returned.
 func (status GlobalMirrorStatus) GetRemoteSiteStatus(ctx context.Context) (types.SiteStatus, error) {
 	var (
 		ss  librbd.SiteMirrorImageStatus
-		err error = librbd.ErrNotExist
+		err error = rbderrors.ErrStatusNotFound
 	)
 
 	for i := range status.SiteStatuses {

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -78,4 +78,7 @@ type VolumeGroup interface {
 	// The Snapshots are crash consistent, and created as a consistency
 	// group.
 	CreateSnapshots(ctx context.Context, cr *util.Credentials, name string) ([]Snapshot, error)
+
+	// ToMirror converts the VolumeGroup to a Mirror.
+	ToMirror() (Mirror, error)
 }

--- a/internal/rbd/types/manager.go
+++ b/internal/rbd/types/manager.go
@@ -18,6 +18,8 @@ package types
 
 import (
 	"context"
+
+	"github.com/csi-addons/spec/lib/go/replication"
 )
 
 // VolumeResolver can be used to construct a Volume from a CSI VolumeId.
@@ -92,4 +94,8 @@ type Manager interface {
 	// RegenerateVolumeGroupJournal regenerate the omap data for the volume group.
 	// returns the volume group handle
 	RegenerateVolumeGroupJournal(ctx context.Context, groupID, requestName string, volumeIds []string) (string, error)
+
+	// GetMirrorSource returns the source of the mirror for the given volume or group.
+	GetMirrorSource(ctx context.Context, volumeID string,
+		rep *replication.ReplicationSource) ([]Volume, Mirror, error)
 }

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -21,9 +21,11 @@ RUN source /build.env \
 # https://github.com/ceph/ceph-container/issues/2034
 # https://github.com/ceph/ceph-container/issues/2141 are fixed.
 RUN true \
-    && dnf -y reinstall https://download.ceph.com/rpm-${CEPH_VERSION}/el9/noarch/ceph-release-1-1.el9.noarch.rpm \
-    && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
-    && true
+    && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=wip-pkalever-rbd-group-snap-mirror&sha1=4fea9830b879b460834a720470e91d519576bb28" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-wip-pkalever-rbd-group-snap-mirror/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
+     && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
+     && true
 
 RUN mkdir -p /etc/selinux && touch /etc/selinux/config
 

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -7,8 +7,7 @@
 # Operating System, so generated binaries and versions of dependencies may be a
 # little different.
 #
-
-FROM quay.io/fedora/fedora:latest
+FROM quay.ceph.io/ceph-ci/ceph:wip-pkalever-rbd-group-snap-mirror
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go
@@ -24,6 +23,13 @@ ENV \
 COPY build.env /
 
 RUN mkdir -p /etc/selinux && touch /etc/selinux/config
+
+RUN true \
+    && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=wip-pkalever-rbd-group-snap-mirror&sha1=4fea9830b879b460834a720470e91d519576bb28" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-wip-pkalever-rbd-group-snap-mirror/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
+     && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
+     && true
 
 RUN source /build.env \
     && \

--- a/vendor/github.com/ceph/go-ceph/rbd/mirror_group.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/mirror_group.go
@@ -1,0 +1,344 @@
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <errno.h>
+// #include <stdlib.h>
+// #include <rados/librados.h>
+// #include <rbd/librbd.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/cutil"
+	"github.com/ceph/go-ceph/rados"
+)
+
+// MirrorGroupEnable will enable mirroring for a group using the specified mode.
+//
+// Implements:
+//
+//	int rbd_mirror_group_enable(rados_ioctx_t p, const char *name,
+//	  							rbd_mirror_image_mode_t mirror_image_mode)
+func MirrorGroupEnable(groupIoctx *rados.IOContext, groupName string, mode ImageMirrorMode) error {
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_enable(
+		cephIoctx(groupIoctx),
+		cGroupName,
+		C.rbd_mirror_image_mode_t(mode))
+
+	return getError(ret)
+}
+
+// MirrorGroupDisable will disable mirroring for a group.
+//
+// Implements:
+//
+//	int rbd_mirror_group_disable(rados_ioctx_t p, const char *name,
+//	  							bool force)
+func MirrorGroupDisable(groupIoctx *rados.IOContext, groupName string, force bool) error {
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_disable(
+		cephIoctx(groupIoctx),
+		cGroupName,
+		C.bool(force))
+
+	return getError(ret)
+}
+
+// MirrorGroupPromote will promote the mirrored group to primary state.
+//
+// Implements:
+//
+//	int rbd_mirror_group_promote(rados_ioctx_t p, const char *name,
+//	  							 bool force)
+func MirrorGroupPromote(groupIoctx *rados.IOContext, groupName string, force bool) error {
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_promote(
+		cephIoctx(groupIoctx),
+		cGroupName,
+		C.bool(force))
+
+	return getError(ret)
+}
+
+// MirrorGroupDemote will demote the mirrored group to secondary state.
+//
+// Implements:
+//
+//	int rbd_mirror_group_demote(rados_ioctx_t p, const char *name)
+func MirrorGroupDemote(groupIoctx *rados.IOContext, groupName string) error {
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_demote(
+		cephIoctx(groupIoctx),
+		cGroupName)
+
+	return getError(ret)
+}
+
+// MirrorGroupResync is used to manually resolve split-brain status by triggering
+// resynchronization.
+//
+// Implements:
+//
+//	int rbd_mirror_group_resync(rados_ioctx_t p, const char *name)
+func MirrorGroupResync(groupIoctx *rados.IOContext, groupName string) error {
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_resync(
+		cephIoctx(groupIoctx),
+		cGroupName)
+
+	return getError(ret)
+}
+
+// MirrorGroupState represents the current state of the mirrored group.
+type MirrorGroupState C.rbd_mirror_group_state_t
+
+// String representation of MirrorGroupState.
+func (mgs MirrorGroupState) String() string {
+	switch mgs {
+	case MirrorGroupEnabled:
+		return "enabled"
+	case MirrorGroupDisabled:
+		return "disabled"
+	case MirrorGroupEnabling:
+		return "enabling"
+	case MirrorGroupDisabling:
+		return "disabling"
+	default:
+		return "<unknown>"
+	}
+}
+
+const (
+	// MirrorGroupDisabling is the representation of
+	// RBD_MIRROR_GROUP_DISABLING from librbd.
+	MirrorGroupDisabling = MirrorGroupState(C.RBD_MIRROR_GROUP_DISABLING)
+	// MirrorGroupEnabling is the representation of
+	// RBD_MIRROR_GROUP_ENABLING from librbd
+	MirrorGroupEnabling = MirrorGroupState(C.RBD_MIRROR_GROUP_ENABLING)
+	// MirrorGroupEnabled is the representation of
+	// RBD_MIRROR_IMAGE_ENABLED from librbd.
+	MirrorGroupEnabled = MirrorGroupState(C.RBD_MIRROR_GROUP_ENABLED)
+	// MirrorGroupDisabled is the representation of
+	// RBD_MIRROR_GROUP_DISABLED from librbd.
+	MirrorGroupDisabled = MirrorGroupState(C.RBD_MIRROR_GROUP_DISABLED)
+)
+
+// MirrorGroupInfo represents the mirroring status information of group.
+type MirrorGroupInfo struct {
+	GlobalID        string
+	State           MirrorGroupState
+	MirrorImageMode ImageMirrorMode
+	Primary         bool
+}
+
+// GetMirrorGroupInfo returns the mirroring info of the group.
+//
+// Implements:
+//
+//	int rbd_mirror_group_get_info(rados_ioctx_t p, const char *name,
+//								  rbd_mirror_group_info_t *mirror_group_info,
+//								  size_t info_size)
+func GetMirrorGroupInfo(groupIoctx *rados.IOContext, groupName string) (*MirrorGroupInfo, error) {
+	var cgInfo C.rbd_mirror_group_info_t
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_get_info(
+		cephIoctx(groupIoctx),
+		cGroupName,
+		&cgInfo,
+		C.sizeof_rbd_mirror_group_info_t)
+
+	if err := getError(ret); err != nil {
+		return &MirrorGroupInfo{}, err
+	}
+
+	info := convertMirrorGroupInfo(&cgInfo)
+
+	// free C memory allocated by C.rbd_mirror_group_get_info call
+	C.rbd_mirror_group_get_info_cleanup(&cgInfo)
+	return &info, nil
+}
+
+func convertMirrorGroupInfo(cgInfo *C.rbd_mirror_group_info_t) MirrorGroupInfo {
+	return MirrorGroupInfo{
+		GlobalID:        C.GoString(cgInfo.global_id),
+		MirrorImageMode: ImageMirrorMode(cgInfo.mirror_image_mode),
+		State:           MirrorGroupState(cgInfo.state),
+		Primary:         bool(cgInfo.primary),
+	}
+}
+
+// MirrorGroupStatusState is used to indicate the state of a mirrored group
+// within the site status info.
+type MirrorGroupStatusState int64
+
+const (
+	// MirrorGroupStatusStateUnknown is equivalent to MIRROR_GROUP_STATUS_STATE_UNKNOWN
+	MirrorGroupStatusStateUnknown = MirrorGroupStatusState(C.MIRROR_GROUP_STATUS_STATE_UNKNOWN)
+	// MirrorGroupStatusStateError is equivalent to MIRROR_GROUP_STATUS_STATE_ERROR
+	MirrorGroupStatusStateError = MirrorGroupStatusState(C.MIRROR_GROUP_STATUS_STATE_ERROR)
+	// MirrorGroupStatusStateStartingReplay is equivalent to MIRROR_GROUP_STATUS_STATE_STARTING_REPLAY
+	MirrorGroupStatusStateStartingReplay = MirrorGroupStatusState(C.MIRROR_GROUP_STATUS_STATE_STARTING_REPLAY)
+	// MirrorGroupStatusStateReplaying is equivalent to MIRROR_GROUP_STATUS_STATE_REPLAYING
+	MirrorGroupStatusStateReplaying = MirrorGroupStatusState(C.MIRROR_GROUP_STATUS_STATE_REPLAYING)
+	// MirrorGroupStatusStateStoppingReplay is equivalent to MIRROR_GROUP_STATUS_STATE_STOPPING_REPLAY
+	MirrorGroupStatusStateStoppingReplay = MirrorGroupStatusState(C.MIRROR_GROUP_STATUS_STATE_STOPPING_REPLAY)
+	// MirrorGroupStatusStateStopped is equivalent to MIRROR_GROUP_STATUS_STATE_STOPPED
+	MirrorGroupStatusStateStopped = MirrorGroupStatusState(C.MIRROR_GROUP_STATUS_STATE_STOPPED)
+)
+
+// String represents the MirrorImageStatusState as a short string.
+func (state MirrorGroupStatusState) String() string {
+	switch state {
+	case MirrorGroupStatusStateUnknown:
+		return "unknown"
+	case MirrorGroupStatusStateError:
+		return "error"
+	case MirrorGroupStatusStateStartingReplay:
+		return "starting_replay"
+	case MirrorGroupStatusStateReplaying:
+		return "replaying"
+	case MirrorGroupStatusStateStoppingReplay:
+		return "stopping_replay"
+	case MirrorGroupStatusStateStopped:
+		return "stopped"
+	default:
+		return fmt.Sprintf("unknown(%d)", state)
+	}
+}
+
+// SiteMirrorGroupStatus contains information pertaining to the status of
+// a mirrored group within a site.
+type SiteMirrorGroupStatus struct {
+	MirrorUUID           string
+	State                MirrorGroupStatusState
+	MirrorImageCount     int
+	MirrorImagePoolIDs   int64
+	MirrorImageGlobalIDs string
+	MirrorImages         []SiteMirrorImageStatus
+	Description          string
+	LastUpdate           int64
+	Up                   bool
+}
+
+// GlobalMirrorGroupStatus contains information pertaining to the global
+// status of a mirrored group. It contains general information as well
+// as per-site information stored in the SiteStatuses slice.
+type GlobalMirrorGroupStatus struct {
+	Name              string
+	Info              MirrorGroupInfo
+	SiteStatusesCount int
+	SiteStatuses      []SiteMirrorGroupStatus
+}
+
+// LocalStatus returns one SiteMirrorGroupStatus item from the SiteStatuses
+// slice that corresponds to the local site's status. If the local status
+// is not found than the error ErrNotExist will be returned.
+func (gmis GlobalMirrorGroupStatus) LocalStatus() (SiteMirrorGroupStatus, error) {
+	for i := range gmis.SiteStatuses {
+		// I couldn't find it explicitly documented, but a site mirror uuid
+		// of an empty string indicates that this is the local site.
+		// This pattern occurs in both the pybind code and ceph c++.
+		if gmis.SiteStatuses[i].MirrorUUID == "" {
+			return gmis.SiteStatuses[i], nil
+		}
+	}
+	return SiteMirrorGroupStatus{}, ErrNotExist
+}
+
+type groupSiteArray [cutil.MaxIdx]C.rbd_mirror_group_site_status_t
+
+// GetGlobalMirrorGroupStatus returns status information pertaining to the state
+// of a groups's mirroring.
+//
+// Implements:
+//
+//	int rbd_mirror_group_get_global_status(
+//		rados_ioctx_t p,
+//		const char *group_name
+//		rbd_mirror_group_global_status_t *mirror_group_status,
+//		size_t status_size);
+func GetGlobalMirrorGroupStatus(ioctx *rados.IOContext, groupName string) (GlobalMirrorGroupStatus, error) {
+	s := C.rbd_mirror_group_global_status_t{}
+	cGroupName := C.CString(groupName)
+	defer C.free(unsafe.Pointer(cGroupName))
+
+	ret := C.rbd_mirror_group_get_global_status(
+		cephIoctx(ioctx),
+		(*C.char)(cGroupName),
+		&s,
+		C.sizeof_rbd_mirror_group_global_status_t)
+	if err := getError(ret); err != nil {
+		return GlobalMirrorGroupStatus{}, err
+	}
+
+	status := newGlobalMirrorGroupStatus(&s)
+	return status, nil
+}
+
+func newGlobalMirrorGroupStatus(s *C.rbd_mirror_group_global_status_t) GlobalMirrorGroupStatus {
+	// Initializing the status object
+	status := GlobalMirrorGroupStatus{
+		Name:              C.GoString(s.name),
+		Info:              convertMirrorGroupInfo(&s.info),
+		SiteStatusesCount: int(s.site_statuses_count),
+		SiteStatuses:      make([]SiteMirrorGroupStatus, s.site_statuses_count),
+	}
+
+	// Check if site statuses are not null before using them
+	if s.site_statuses != nil && s.site_statuses_count > 0 {
+		gsscs := (*groupSiteArray)(unsafe.Pointer(s.site_statuses))[:s.site_statuses_count:s.site_statuses_count]
+		for i := C.uint32_t(0); i < s.site_statuses_count; i++ {
+			gss := gsscs[i]
+			// Ensure that fields are valid before using them
+			if gss.mirror_uuid != nil && gss.mirror_image_global_ids != nil {
+				status.SiteStatuses[i] = SiteMirrorGroupStatus{
+					MirrorUUID:           C.GoString(gss.mirror_uuid),
+					MirrorImageGlobalIDs: C.GoString(*gss.mirror_image_global_ids),
+					MirrorImagePoolIDs:   int64(*gss.mirror_image_pool_ids),
+					State:                MirrorGroupStatusState(gss.state),
+					Description:          C.GoString(gss.description),
+					MirrorImageCount:     int(gss.mirror_image_count),
+					LastUpdate:           int64(gss.last_update),
+					MirrorImages:         make([]SiteMirrorImageStatus, gss.mirror_image_count),
+					Up:                   bool(gss.up),
+				}
+
+				// Check if the mirror_images pointer is valid
+				if gss.mirror_images != nil && gss.mirror_image_count > 0 {
+
+					sscs := (*siteArray)(unsafe.Pointer(gss.mirror_images))[:gss.mirror_image_count:gss.mirror_image_count]
+					for j := C.uint32_t(0); j < gss.mirror_image_count; j++ {
+						ss := sscs[j]
+
+						// Ensure that fields are valid before using them
+						if ss.mirror_uuid != nil {
+							status.SiteStatuses[i].MirrorImages[j] = SiteMirrorImageStatus{
+								MirrorUUID:  C.GoString(ss.mirror_uuid),
+								State:       MirrorImageStatusState(ss.state),
+								Description: C.GoString(ss.description),
+								LastUpdate:  int64(ss.last_update),
+								Up:          bool(ss.up),
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return status
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,7 +195,7 @@ github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e
+# github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e => github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453
 ## explicit; go 1.22
 github.com/ceph/go-ceph/cephfs
 github.com/ceph/go-ceph/cephfs/admin
@@ -1246,4 +1246,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/ceph/ceph-csi/api => ./api
+# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453
 # k8s.io/client-go => k8s.io/client-go v0.32.2


### PR DESCRIPTION
This PR adds the required support volume group mirroring which includes:
- implementing Mirror interface for volume group
- handle replication for both volume group and volume as source
- delete only omap data when the group is secondary
- support for static groups in rbd

NOTE: We need the updated go-ceph for group mirroring, depends on https://github.com/red-hat-storage/go-ceph/pull/1, once it is merged the same will be added to this PR.

This is PR is on top of the changes made in https://github.com/ceph/ceph-csi/pull/4739, credits to @Madhu-1 for the initial PR.