### PR TITLE
[DOWNSTREAM-ONLY] ci: disable dependabot PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,8 @@ updates:
     commit-message:
       prefix: "rebase"
   - package-ecosystem: "gomod"
+    # ODF only: disable PR creation, synced from upstream
+    open-pull-requests-limit: 0
     directory: "/e2e"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot does not need to report available updates for vendored dependencies in the downstream repository. Updates to dependencies are synced from the upstream repository when needed. There is also the "Upstream First" requirement, which we follow closely.

See-also: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit

Closes: #503