### PR TITLE
DFBUGS-2091: util: fix bug in health checker

### DIFF
--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -137,7 +137,8 @@ func (hcm *healthCheckManager) startStatChecker(volumeID, path string, shared bo
 // are key'd by theit volumeID+path.
 func (hcm *healthCheckManager) startChecker(cc ConditionChecker, volumeID, path string, shared bool) error {
 	key := volumeID
-	if shared {
+	if !shared {
+		// if it is non-shared checker, try to use the path as well.
 		key = fallbackKey(volumeID, path)
 	}
 

--- a/internal/health-checker/manager_test.go
+++ b/internal/health-checker/manager_test.go
@@ -18,12 +18,15 @@ package healthchecker
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+const volumeID = "fake-volume-id"
 
 func TestManager(t *testing.T) {
 	t.Parallel()
 
-	volumeID := "fake-volume-id"
 	volumePath := t.TempDir()
 	mgr := NewHealthCheckManager()
 
@@ -52,7 +55,6 @@ func TestManager(t *testing.T) {
 func TestSharedChecker(t *testing.T) {
 	t.Parallel()
 
-	volumeID := "fake-volume-id"
 	volumePath := t.TempDir()
 	mgr := NewHealthCheckManager()
 
@@ -82,4 +84,54 @@ func TestSharedChecker(t *testing.T) {
 
 	t.Log("stop the checker")
 	mgr.StopSharedChecker(volumeID)
+}
+
+func TestTwoNonSharedChecker(t *testing.T) {
+	t.Parallel()
+
+	// create two different paths for same volumeID
+	// to test if the checkers are independent
+	firstVolumePath := t.TempDir()
+	secondVolumePath := t.TempDir()
+	mgr := NewHealthCheckManager()
+
+	t.Log("start the first checker")
+	err := mgr.StartChecker(volumeID, firstVolumePath, StatCheckerType)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health for first path, should be healthy")
+	healthy, msg := mgr.IsHealthy(volumeID, firstVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("check health for second path, should error out since checker is not started")
+	_, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	require.ErrorContains(t, msg, "no ConditionChecker for volume-id")
+
+	t.Log("start the second checker")
+	err = mgr.StartChecker(volumeID, secondVolumePath, StatCheckerType)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health, should be healthy")
+	healthy, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("stop the first checker")
+	mgr.StopChecker(volumeID, firstVolumePath)
+
+	t.Log("check health of second path, should still be healthy")
+	healthy, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("stop the second checker")
+	mgr.StopChecker(volumeID, secondVolumePath)
 }


### PR DESCRIPTION
This commit fixes a bug in health checker that
caused shared checker to get keyed with volumeID+volumepath instead of just volumeID and the other way around
for non-shared checkers.

Signed-off-by: Rakshith R <rar@redhat.com>
(cherry picked from commit 86f2ad9e0dd17b607e213671cba8164ef374849e)
