### PR TITLE
[DOWNSTREAM-ONLY] [release-4.19] DFBUGS-2348: group: use groupsnapshotschedule api for group mirror

### DIFF
--- a/deploy/cephcsi/image/Dockerfile
+++ b/deploy/cephcsi/image/Dockerfile
@@ -9,8 +9,8 @@ FROM ${BASE_IMAGE} as updated_base
 # https://github.com/ceph/ceph-container/issues/2141 are fixed.
 RUN true \
     && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
-    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=wip-pkalever-rbd-group-snap-mirror&sha1=4fea9830b879b460834a720470e91d519576bb28" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
-    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-wip-pkalever-rbd-group-snap-mirror/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=${CEPH_REF}&sha1=${CEPH_SHA:-latest}" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-${CEPH_REF}/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
      && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
      && true
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
-replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453
+replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5
 
 require (
 	// sigs.k8s.io/controller-runtime wants this version, it gets replaced below

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453 h1:aSVOMbsLGszJJ5YYYcka8MHP8O5CPS1IcYDNsuSktes=
-github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453/go.mod h1:V++4AyPoTN50AtoHAZQ63lN0galqGLFE1b7aS0gO1Es=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5 h1:OZaxewnZ8Fu+taUkFl4Fl4VEMtDlVLDhShyPUObnNmk=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5/go.mod h1:V++4AyPoTN50AtoHAZQ63lN0galqGLFE1b7aS0gO1Es=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/internal/rbd/group/group_mirror.go
+++ b/internal/rbd/group/group_mirror.go
@@ -212,12 +212,12 @@ func (vgm *volumeGroupMirror) GetGlobalMirroringStatus(ctx context.Context) (typ
 }
 
 func (vgm *volumeGroupMirror) AddSnapshotScheduling(interval admin.Interval, startTime admin.StartTime) error {
-	ls := admin.NewLevelSpec(vgm.pool, vgm.namespace, "")
+	ls := admin.NewGroupLevelSpec(vgm.pool, vgm.namespace, vgm.name)
 	ra, err := vgm.conn.GetRBDAdmin()
 	if err != nil {
 		return err
 	}
-	adminConn := ra.MirrorSnashotSchedule()
+	adminConn := ra.GroupSnapshotSchedule()
 	err = adminConn.Add(ls, interval, startTime)
 	if err != nil {
 		return err

--- a/scripts/Dockerfile.devel
+++ b/scripts/Dockerfile.devel
@@ -22,8 +22,8 @@ RUN source /build.env \
 # https://github.com/ceph/ceph-container/issues/2141 are fixed.
 RUN true \
     && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
-    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=wip-pkalever-rbd-group-snap-mirror&sha1=4fea9830b879b460834a720470e91d519576bb28" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
-    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-wip-pkalever-rbd-group-snap-mirror/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=${CEPH_REF}&sha1=${CEPH_SHA:-latest}" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-${CEPH_REF}/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
      && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
      && true
 

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -26,8 +26,8 @@ RUN mkdir -p /etc/selinux && touch /etc/selinux/config
 
 RUN true \
     && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
-    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=wip-pkalever-rbd-group-snap-mirror&sha1=4fea9830b879b460834a720470e91d519576bb28" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
-    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-wip-pkalever-rbd-group-snap-mirror/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" = true ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=${CEPH_REF}&sha1=${CEPH_SHA:-latest}" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo -a "$CEPH_IS_DEVEL" != true ]; then yum reinstall -y "https://download.ceph.com/rpm-${CEPH_REF}/el9/noarch/ceph-release-1-1.el9.noarch.rpm"; fi \
      && ( dnf config-manager --disable tcmu-runner,tcmu-runner-source,tcmu-runner-noarch,ceph-iscsi,ganesha || true ) \
      && true
 

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/admin.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/admin.go
@@ -43,6 +43,22 @@ func NewLevelSpec(pool, namespace, image string) LevelSpec {
 	return LevelSpec{s}
 }
 
+// NewGroupLevelSpec is used to construct a LevelSpec given a pool and
+// optional namespace and group names.
+func NewGroupLevelSpec(pool, namespace, group string) LevelSpec {
+	var s string
+	if group != "" && namespace != "" {
+		s = fmt.Sprintf("%s/%s/%s", pool, namespace, group)
+	} else if group != "" {
+		s = fmt.Sprintf("%s/%s", pool, group)
+	} else if namespace != "" {
+		s = fmt.Sprintf("%s/%s/", pool, namespace)
+	} else {
+		s = fmt.Sprintf("%s/", pool)
+	}
+	return LevelSpec{s}
+}
+
 // NewRawLevelSpec returns a LevelSpec directly based on the spec string
 // argument without constructing it from component values. This should only be
 // used if NewLevelSpec can not create the levelspec value you want to pass to

--- a/vendor/github.com/ceph/go-ceph/rbd/admin/groupsschedule.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/admin/groupsschedule.go
@@ -1,0 +1,42 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package admin
+
+import (
+	ccom "github.com/ceph/go-ceph/common/commands"
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+// GroupSnapshotScheduleAdmin encapsulates management functions for
+// ceph rbd mirror group snapshot schedules.
+type GroupSnapshotScheduleAdmin struct {
+	conn ccom.MgrCommander
+}
+
+// GroupSnapshotSchedule returns a GroupSnapshotScheduleAdmin type for
+// managing ceph rbd mirror group snapshot schedules.
+func (ra *RBDAdmin) GroupSnapshotSchedule() *GroupSnapshotScheduleAdmin {
+	return &GroupSnapshotScheduleAdmin{conn: ra.conn}
+}
+
+// Add a new group snapshot schedule to the given pool/group based on the supplied
+// level spec.
+//
+// Similar To:
+//
+//	rbd mirror group snapshot schedule add <level_spec> <interval> <start_time>
+func (mss *GroupSnapshotScheduleAdmin) Add(l LevelSpec, i Interval, s StartTime) error {
+	m := map[string]string{
+		"prefix":     "rbd mirror group snapshot schedule add",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	if i != NoInterval {
+		m["interval"] = string(i)
+	}
+	if s != NoStartTime {
+		m["start_time"] = string(s)
+	}
+	return commands.MarshalMgrCommand(mss.conn, m).NoData().End()
+}

--- a/vendor/github.com/ceph/go-ceph/rbd/mirror_group.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/mirror_group.go
@@ -1,3 +1,6 @@
+//go:build ceph_preview
+// +build ceph_preview
+
 package rbd
 
 // #cgo LDFLAGS: -lrbd

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,7 +195,7 @@ github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e => github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453
+# github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e => github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5
 ## explicit; go 1.22
 github.com/ceph/go-ceph/cephfs
 github.com/ceph/go-ceph/cephfs/admin
@@ -1246,5 +1246,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/ceph/ceph-csi/api => ./api
-# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250325152246-a539ad02e453
+# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5
 # k8s.io/client-go => k8s.io/client-go v0.32.2


### PR DESCRIPTION
use groupsnapshotschedule api for group mirror schedule operation.

**NOTE:** This is a downstream only change, because we don't have `mirror group snapshot schedule` support in upstream release, yet.