### PR TITLE
[release-4.18] DFBUGS-2321: util: fix bug in health checker

### DIFF
--- a/internal/health-checker/manager.go
+++ b/internal/health-checker/manager.go
@@ -137,7 +137,8 @@ func (hcm *healthCheckManager) startStatChecker(volumeID, path string, shared bo
 // are key'd by theit volumeID+path.
 func (hcm *healthCheckManager) startChecker(cc ConditionChecker, volumeID, path string, shared bool) error {
 	key := volumeID
-	if shared {
+	if !shared {
+		// if it is non-shared checker, try to use the path as well.
 		key = fallbackKey(volumeID, path)
 	}
 

--- a/internal/health-checker/manager_test.go
+++ b/internal/health-checker/manager_test.go
@@ -18,12 +18,15 @@ package healthchecker
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+const volumeID = "fake-volume-id"
 
 func TestManager(t *testing.T) {
 	t.Parallel()
 
-	volumeID := "fake-volume-id"
 	volumePath := t.TempDir()
 	mgr := NewHealthCheckManager()
 
@@ -52,7 +55,6 @@ func TestManager(t *testing.T) {
 func TestSharedChecker(t *testing.T) {
 	t.Parallel()
 
-	volumeID := "fake-volume-id"
 	volumePath := t.TempDir()
 	mgr := NewHealthCheckManager()
 
@@ -82,4 +84,54 @@ func TestSharedChecker(t *testing.T) {
 
 	t.Log("stop the checker")
 	mgr.StopSharedChecker(volumeID)
+}
+
+func TestTwoNonSharedChecker(t *testing.T) {
+	t.Parallel()
+
+	// create two different paths for same volumeID
+	// to test if the checkers are independent
+	firstVolumePath := t.TempDir()
+	secondVolumePath := t.TempDir()
+	mgr := NewHealthCheckManager()
+
+	t.Log("start the first checker")
+	err := mgr.StartChecker(volumeID, firstVolumePath, StatCheckerType)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health for first path, should be healthy")
+	healthy, msg := mgr.IsHealthy(volumeID, firstVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("check health for second path, should error out since checker is not started")
+	_, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	require.ErrorContains(t, msg, "no ConditionChecker for volume-id")
+
+	t.Log("start the second checker")
+	err = mgr.StartChecker(volumeID, secondVolumePath, StatCheckerType)
+	if err != nil {
+		t.Fatalf("ConditionChecker could not get started: %v", err)
+	}
+
+	t.Log("check health, should be healthy")
+	healthy, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("stop the first checker")
+	mgr.StopChecker(volumeID, firstVolumePath)
+
+	t.Log("check health of second path, should still be healthy")
+	healthy, msg = mgr.IsHealthy(volumeID, secondVolumePath)
+	if !healthy || err != nil {
+		t.Errorf("volume is unhealthy: %s", msg)
+	}
+
+	t.Log("stop the second checker")
+	mgr.StopChecker(volumeID, secondVolumePath)
 }

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -33,6 +33,7 @@ RUN source /build.env \
 	make \
 	gcc \
 	findutils \
+	awk \
 	librados-devel \
         libcephfs-devel \
 	librbd-devel \


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
