### PR TITLE
DFBUGS-2871: release-4.18] rbd: flattenClonedRbdImages() may require namespace

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -604,6 +604,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			children,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {
@@ -639,6 +640,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			children,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -788,12 +788,13 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 func flattenClonedRbdImages(
 	ctx context.Context,
 	children []string,
-	pool, monitors, rbdImageName string,
+	pool, monitors, radosNamespace, rbdImageName string,
 	cr *util.Credentials,
 ) error {
 	rv := &rbdVolume{}
 	rv.Monitors = monitors
 	rv.Pool = pool
+	rv.RadosNamespace = radosNamespace
 	rv.RbdImageName = rbdImageName
 
 	defer rv.Destroy(ctx)


### PR DESCRIPTION
flattenClonedRbdImages() requires namespace if it not the default one.

(cherry picked from commit b0eb42823f7ad95072ca82cd02f186d0736f678e)

