### PR TITLE
DFBUGS-2873: [release-4.16] rbd: flattenClonedRbdImages() may require namespace

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -577,6 +577,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			snaps,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {
@@ -602,6 +603,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			snaps,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -749,12 +749,13 @@ type trashSnapInfo struct {
 func flattenClonedRbdImages(
 	ctx context.Context,
 	snaps []librbd.SnapInfo,
-	pool, monitors, rbdImageName string,
+	pool, monitors, radosNamespace, rbdImageName string,
 	cr *util.Credentials,
 ) error {
 	rv := &rbdVolume{}
 	rv.Monitors = monitors
 	rv.Pool = pool
+	rv.RadosNamespace = radosNamespace
 	rv.RbdImageName = rbdImageName
 
 	defer rv.Destroy()


### PR DESCRIPTION
flattenClonedRbdImages() requires namespace if it not the default one.


(cherry picked from commit b0eb42823f7ad95072ca82cd02f186d0736f678e)

