### PR TITLE
DFBUGS-3798: rbd: consider lastSyncTimeNotFound as image not syncing

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -756,6 +756,8 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 				err.Error())
 		}
 
+		// If the savedImageTime is not empty,
+		// then the image might be in need of resync.
 		if savedImageTime != "" {
 			st, sErr := timestampFromString(savedImageTime)
 			if sErr != nil {
@@ -763,12 +765,23 @@ func (rs *ReplicationServer) ResyncVolume(ctx context.Context,
 			}
 			log.DebugLog(ctx, "image %s, savedImageTime=%v, currentImageTime=%v", vol, st, creationTime)
 
+			// Fetch the last sync info from the local status in order
+			// to determine if the image is syncing or not.
 			syncInfo, sErr := localStatus.GetLastSyncInfo(ctx)
-			if sErr != nil {
+			if sErr != nil && !errors.Is(sErr, rbderrors.ErrLastSyncTimeNotFound) {
 				return nil, status.Errorf(codes.Internal, "failed to get last sync info: %s", sErr.Error())
 			}
+			// consider the image to be not syncing if either
+			// - the last sync time was not found
+			// or
+			// - the sync info indicates the image is not syncing
+			isNotSyncing := errors.Is(sErr, rbderrors.ErrLastSyncTimeNotFound) || !syncInfo.IsSyncing()
 
-			if req.GetForce() && st.Equal(*creationTime) && !syncInfo.IsSyncing() {
+			// image needs to be resynced if
+			// - force option is set
+			// - image creation time is equal to the saved image creation time
+			// - image is not already in syncing state
+			if req.GetForce() && st.Equal(*creationTime) && isNotSyncing {
 				err = mirror.Resync(ctx)
 				if err != nil {
 					return nil, getGRPCError(err)


### PR DESCRIPTION
This commit modifies code to consider image as not syncing when the lastSyncTime is not found.

Currently replication's Resync call fails if the
lastSyncTime of an image is not found.
Instead, we should treat missing lastSyncTime as
the image not being in Syncing state.


(cherry picked from commit fa9e254f41bbf0ba1cb49e5c8abf5fdde8134438)

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Provide some context for the reviewer

## Is there anything that requires special attention ##

Do you have any questions?

Is the change backward compatible?

Are there concerns around backward compatibility?

Provide any external context for the change, if any.

For example:

* Kubernetes links that explain why the change is required
* CSI spec related changes/catch-up that necessitates this patch
* golang related practices that necessitates this change

## Related issues ##

Mention any github issues relevant to this PR. Adding below line
will help to auto close the issue once the PR is merged.

Fixes: #issue_number

## Future concerns ##

List items that are not part of the PR and do not impact it's
functionality, but are work items that can be taken up subsequently.

**Checklist:**

* [ ] **Commit Message Formatting**: Commit titles and messages follow
  guidelines in the [developer
  guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [ ] Reviewed the developer guide on [Submitting a Pull
  Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release
  notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md)
  updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
