### PR TITLE
[release-4.20]: RHSTOR-7595:  Store userid in metadata

### DIFF
--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -363,6 +363,26 @@ var _ = Describe(cephfsType, func() {
 				})
 			}
 
+			By("verify userId mapping metadata exists", func() {
+				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
+				if err != nil {
+					framework.Failf("failed to create CephFS storageclass: %v", err)
+				}
+
+				err = verifyUserIdMappingMetadata(f, pvcPath, appPath, cephfsType)
+				if err != nil {
+					framework.Failf("failed to verify userId mapping metadata exists: %v", err)
+				}
+
+				validateSubvolumeCount(f, 0, fileSystemName, subvolumegroup)
+				validateOmapCount(f, 0, cephfsType, metadataPool, volumesType)
+
+				err = deleteResource(cephFSExamplePath + "storageclass.yaml")
+				if err != nil {
+					framework.Failf("failed to delete CephFS storageclass: %v", err)
+				}
+			})
+
 			By("verify client address metadata exists", func() {
 				err := createCephfsStorageClass(f.ClientSet, f, true, nil)
 				if err != nil {
@@ -1976,6 +1996,12 @@ var _ = Describe(cephfsType, func() {
 				)
 				if err != nil {
 					logAndFail("failed to verify client address metadata of snapshot-backed PVC: %v", err)
+				}
+				err = verifyUserIdMappingMetadataSnapshotBacked(
+					f, pvcClone, appClone, backingSubvolumeNameData.imageName, backingSnapshotName,
+				)
+				if err != nil {
+					logAndFail("failed to verify user ID mapping metadata of snapshot-backed PVC: %v", err)
 				}
 
 				// Snapshot-backed volume shouldn't contribute to total subvolume count.

--- a/e2e/cephfs_helper.go
+++ b/e2e/cephfs_helper.go
@@ -690,3 +690,32 @@ func verifyClientAddressMetadataSnapshotBacked(
 
 	return nil
 }
+
+func verifyUserIdMappingMetadataSnapshotBacked(
+	f *framework.Framework,
+	pvc *v1.PersistentVolumeClaim,
+	pod *v1.Pod,
+	subVolumeName, snapshotName string,
+) error {
+	nodeId := pod.Spec.NodeName
+	_, pvObject, err := getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get PVC and PV: %w", err)
+	}
+	volumeHandle := pvObject.Spec.CSI.VolumeHandle
+
+	expectedValue := keyringCephFSNodePluginUsername
+	metadataKey := fmt.Sprintf(".cephfs.csi.ceph.com/userid/%s/%s", volumeHandle, nodeId)
+	metadataValue, err := getCephFSSnapshotMetadata(
+		f, fileSystemName, subVolumeName, snapshotName, subvolumegroup, metadataKey)
+	if err != nil {
+		return fmt.Errorf("failed to get subvolume snapshot metadata %s: %w", metadataKey, err)
+	}
+
+	if metadataValue != expectedValue {
+		return fmt.Errorf("userId mapping metadata %s has unexpected value %s, expected %s",
+			metadataKey, metadataValue, expectedValue)
+	}
+
+	return nil
+}

--- a/e2e/pod.go
+++ b/e2e/pod.go
@@ -688,7 +688,7 @@ func verifyReadAffinity(
 		configInfos, stdErr, err = execCommandInContainer(f, command, ns, cn, &opt)
 		if strings.TrimSpace(configInfos) != "" {
 			framework.Logf("configInfos: %v, err=%v", configInfos, err)
-			//override error if the configInfo is found.
+			// override error if the configInfo is found.
 			err = nil
 			break
 		}
@@ -748,88 +748,16 @@ func verifyReadAffinity(
 	return nil
 }
 
-func verifyClientAddressMetadataExists(
+func verifyMetadataRemoved(
 	f *framework.Framework,
-	pvcPath, appPath string,
-	driverType string,
+	metadataKey, driverType, rbdImageSpec, subvolumeName string,
 ) error {
-	// create PVC
-	pvc, err := loadPVC(pvcPath)
-	if err != nil {
-		return fmt.Errorf("failed to load pvc: %w", err)
-	}
-	pvc.Namespace = f.UniqueName
-	err = createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout)
-	if err != nil {
-		return fmt.Errorf("failed to create PVC: %w", err)
-	}
-
-	app, err := loadApp(appPath)
-	if err != nil {
-		return fmt.Errorf("failed to load application: %w", err)
-	}
-	app.Namespace = f.UniqueName
-	err = createApp(f.ClientSet, app, deployTimeout)
-	if err != nil {
-		return fmt.Errorf("failed to create application: %w", err)
-	}
-
-	pod, err := getPod(f.ClientSet, app.Namespace, app.Name)
-	if err != nil {
-		return fmt.Errorf("failed to get pod: %w", err)
-	}
-	nodeId := pod.Spec.NodeName
-
-	var (
-		metadataKey   string
-		metadataValue string
-		rbdImageSpec  string
-		subVolumeName string
-	)
-
-	_, pvObject, err := getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
-	if err != nil {
-		framework.Logf("error getting pvc %q in namespace %q: %v", pvc.Name, pvc.Namespace, err)
-		return fmt.Errorf("failed to get PVC and PV: %w", err)
-	}
-	volumeHandle := pvObject.Spec.CSI.VolumeHandle
-
-	// First, get the metadata while the pod is running to verify it exists
-	switch driverType {
-	case rbdType:
-		metadataKey = fmt.Sprintf(".rbd.csi.ceph.com/clientaddress/%s/%s", volumeHandle, nodeId)
-
-		imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
-		if err != nil {
-			return err
-		}
-
-		rbdImageSpec = imageSpec(defaultRBDPool, imageData.imageName)
-		metadataValue, err = getImageMeta(rbdImageSpec, metadataKey, f)
-		if err != nil {
-			return fmt.Errorf("failed to get image metadata %s: %w", metadataKey, err)
-		}
-	case cephfsType:
-		metadataKey = fmt.Sprintf(".cephfs.csi.ceph.com/clientaddress/%s/%s", volumeHandle, nodeId)
-		subVolumeName = pvObject.Spec.CSI.VolumeAttributes["subvolumeName"]
-		metadataValue, err = getCephFSSubvolumeMetadata(
-			f, fileSystemName, subVolumeName, subvolumegroup, metadataKey)
-		if err != nil {
-			return fmt.Errorf("failed to get subvolume metadata %s: %w", metadataKey, err)
-		}
-	}
-
-	if metadataValue == "" {
-		return fmt.Errorf("client address metadata %s value is empty", metadataKey)
-	}
-
-	err = deletePod(pod.Name, pod.Namespace, f.ClientSet, deployTimeout)
-	if err != nil {
-		return fmt.Errorf("failed to delete pod: %w", err)
-	}
-
-	// verify clientaddress metadata is removed after pod deletion
+	// verify metadata is removed after pod deletion
 	// retry up to 3 times with 10-second intervals
+	var (
+		metadataValue string
+		err           error
+	)
 	maxRetries := 3
 	retryInterval := 10 * time.Second
 
@@ -839,28 +767,173 @@ func verifyClientAddressMetadataExists(
 			metadataValue, err = getImageMeta(rbdImageSpec, metadataKey, f)
 		case cephfsType:
 			metadataValue, err = getCephFSSubvolumeMetadata(
-				f, fileSystemName, subVolumeName, subvolumegroup, metadataKey)
+				f, fileSystemName, subvolumeName, subvolumegroup, metadataKey)
 		}
 
 		if err != nil && strings.Contains(err.Error(), "command terminated with exit code 2") {
-			framework.Logf("clientaddress metadata %s successfully removed", metadataKey)
+			framework.Logf("metadata %s successfully removed", metadataKey)
 			break
 		}
 
-		framework.Logf("clientaddress metadata %s still exists with value %s, retrying (%d/%d)",
+		framework.Logf("metadata %s still exists with value %s, retrying (%d/%d)",
 			metadataKey, metadataValue, attempt, maxRetries)
 
 		if attempt == maxRetries {
-			return fmt.Errorf("clientaddress metadata %s still exists with value %s (after %d attempts)",
+			return fmt.Errorf("metadata %s still exists with value %s (after %d attempts)",
 				metadataKey, metadataValue, maxRetries)
 		}
 		time.Sleep(retryInterval)
 	}
 
-	err = deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+	return nil
+}
+
+func getAppAndPVC(
+	f *framework.Framework,
+	pvcPath, appPath string,
+) (*v1.Pod, *v1.PersistentVolumeClaim, error) {
+	pvc, err := loadPVC(pvcPath)
 	if err != nil {
-		return fmt.Errorf("failed to delete PVC: %w", err)
+		return nil, nil, fmt.Errorf("failed to load pvc: %w", err)
+	}
+	pvc.Namespace = f.UniqueName
+	if err := createPVCAndvalidatePV(f.ClientSet, pvc, deployTimeout); err != nil {
+		return nil, nil, fmt.Errorf("failed to create PVC: %w", err)
 	}
 
-	return nil
+	app, err := loadApp(appPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load application: %w", err)
+	}
+	app.Namespace = f.UniqueName
+	if err := createApp(f.ClientSet, app, deployTimeout); err != nil {
+		return nil, nil, fmt.Errorf("failed to create application: %w", err)
+	}
+
+	pod, err := getPod(f.ClientSet, app.Namespace, app.Name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get pod: %w", err)
+	}
+
+	pvc, _, err = getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get PVC and PV: %w", err)
+	}
+
+	return pod, pvc, nil
+}
+
+func verifyClientAddressMetadataExists(
+	f *framework.Framework,
+	pvcPath, appPath string,
+	driverType string,
+) error {
+	var (
+		metadataKey   string
+		metadataValue string
+		rbdImageSpec  string
+		subvolumeName string
+		err           error
+	)
+
+	pod, pvc, err := getAppAndPVC(f, pvcPath, appPath)
+	if err != nil {
+		return err
+	}
+	_, pv, err := getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get PVC and PV: %w", err)
+	}
+
+	nodeId := pod.Spec.NodeName
+	volumeHandle := pv.Spec.CSI.VolumeHandle
+	switch driverType {
+	case rbdType:
+		metadataKey = fmt.Sprintf(".rbd.csi.ceph.com/clientaddress/%s/%s", volumeHandle, nodeId)
+		imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+		if err != nil {
+			return err
+		}
+		rbdImageSpec = imageSpec(defaultRBDPool, imageData.imageName)
+		metadataValue, err = getImageMeta(rbdImageSpec, metadataKey, f)
+	case cephfsType:
+		metadataKey = fmt.Sprintf(".cephfs.csi.ceph.com/clientaddress/%s/%s", volumeHandle, nodeId)
+		subvolumeName = pv.Spec.CSI.VolumeAttributes["subvolumeName"]
+		metadataValue, err = getCephFSSubvolumeMetadata(f, fileSystemName, subvolumeName, subvolumegroup, metadataKey)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get metadata %s: %w", metadataKey, err)
+	}
+	if metadataValue == "" {
+		return fmt.Errorf("client address metadata %s value is empty", metadataKey)
+	}
+
+	if err := deletePod(pod.Name, pod.Namespace, f.ClientSet, deployTimeout); err != nil {
+		return fmt.Errorf("failed to delete pod: %w", err)
+	}
+
+	if err := verifyMetadataRemoved(f, metadataKey, driverType, rbdImageSpec, subvolumeName); err != nil {
+		return fmt.Errorf("failed to verify metadata removal: %w", err)
+	}
+
+	return deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
+}
+
+func verifyUserIdMappingMetadata(
+	f *framework.Framework,
+	pvcPath, appPath string,
+	driverType string,
+) error {
+	var (
+		metadataKey   string
+		metadataValue string
+		expectedValue string
+		rbdImageSpec  string
+		subvolumeName string
+		err           error
+	)
+
+	pod, pvc, err := getAppAndPVC(f, pvcPath, appPath)
+	if err != nil {
+		return err
+	}
+	_, pv, err := getPVCAndPV(f.ClientSet, pvc.Name, pvc.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get PVC and PV: %w", err)
+	}
+
+	nodeId := pod.Spec.NodeName
+	volumeHandle := pv.Spec.CSI.VolumeHandle
+	switch driverType {
+	case rbdType:
+		expectedValue = keyringRBDNodePluginUsername
+		metadataKey = fmt.Sprintf(".rbd.csi.ceph.com/userid/%s/%s", volumeHandle, nodeId)
+		imageData, err := getImageInfoFromPVC(pvc.Namespace, pvc.Name, f)
+		if err != nil {
+			return err
+		}
+		rbdImageSpec = imageSpec(defaultRBDPool, imageData.imageName)
+		metadataValue, err = getImageMeta(rbdImageSpec, metadataKey, f)
+	case cephfsType:
+		expectedValue = keyringCephFSNodePluginUsername
+		metadataKey = fmt.Sprintf(".cephfs.csi.ceph.com/userid/%s/%s", volumeHandle, nodeId)
+		subvolumeName = pv.Spec.CSI.VolumeAttributes["subvolumeName"]
+		metadataValue, err = getCephFSSubvolumeMetadata(f, fileSystemName, subvolumeName, subvolumegroup, metadataKey)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get metadata %s: %w", metadataKey, err)
+	}
+	if metadataValue != expectedValue {
+		return fmt.Errorf("userId mapping metadata %s has unexpected value %s, expected %s", metadataKey, metadataValue, expectedValue)
+	}
+
+	if err := deletePod(pod.Name, pod.Namespace, f.ClientSet, deployTimeout); err != nil {
+		return fmt.Errorf("failed to delete pod: %w", err)
+	}
+
+	if err := verifyMetadataRemoved(f, metadataKey, driverType, rbdImageSpec, subvolumeName); err != nil {
+		return fmt.Errorf("failed to verify metadata removal: %w", err)
+	}
+
+	return deletePVCAndValidatePV(f.ClientSet, pvc, deployTimeout)
 }

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -532,6 +532,17 @@ var _ = Describe("RBD", func() {
 				})
 			}
 
+			By("verify userId mapping metadata exists", func() {
+				err := verifyUserIdMappingMetadata(f, pvcPath, appPath, rbdType)
+				if err != nil {
+					framework.Failf("failed to verify userId mapping metadata exists: %v", err)
+				}
+
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0, defaultRBDPool)
+				validateOmapCount(f, 0, rbdType, defaultRBDPool, volumesType)
+			})
+
 			By("verify client address metadata exists", func() {
 				err := verifyClientAddressMetadataExists(f, pvcPath, appPath, rbdType)
 				if err != nil {

--- a/internal/cephfs/controllerserver.go
+++ b/internal/cephfs/controllerserver.go
@@ -1288,6 +1288,11 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	}
 	defer volOptions.Destroy()
 
+	err = cs.removeUserIdMapping(ctx, volumeId, req.GetNodeId(), secrets, volOptions)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	err = cs.fenceNode(ctx, volumeId, req.GetNodeId(), secrets, volOptions)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -1338,6 +1343,51 @@ func (cs *ControllerServer) getSubvolumeMetadataHandler(
 		unsetAllMetadataFunc: subvolumeClient.UnsetAllMetadata,
 		listMetadataFunc:     subvolumeClient.ListMetadata,
 	}, nil
+}
+
+// removeUserIdMapping attempts to remove nodeId:userId mapping in metadata from the subvolume.
+//
+// Parameters:
+//   - volumeId: The ID of the volume for which we want to remove the user ID mapping.
+//   - nodeId: The ID of the node that we want to remove the user ID mapping for.
+//   - volOptions: The volume options for the CephFS subvolume.
+//
+// Behavior:
+//   - If the '--setmetadata' flag is set to false in CSI driver configuration, does nothing.
+//   - Removes the user ID mapping metadata for the specified nodeId from the subvolume.
+func (cs *ControllerServer) removeUserIdMapping(
+	ctx context.Context,
+	volumeId, nodeId string,
+	secrets map[string]string,
+	volOptions *store.VolumeOptions,
+) error {
+	if !cs.SetMetadata {
+		return nil
+	}
+	if nodeId == "" {
+		return errors.New("nodeId cannot be empty")
+	}
+
+	cr, err := util.NewAdminCredentials(secrets)
+	if err != nil {
+		return fmt.Errorf("failed to create credentials from secrets: %w", err)
+	}
+	defer cr.DeleteCredentials()
+
+	metadataKey := core.GetUserIDMappingKey(volumeId, nodeId)
+	handler, err := cs.getSubvolumeMetadataHandler(ctx, volOptions, secrets)
+	if err != nil {
+		return err
+	}
+
+	err = handler.unsetAllMetadataFunc([]string{metadataKey})
+	if err != nil {
+		return fmt.Errorf("failed to remove metadata %s from %s: %w", metadataKey, handler.logSubvolumeName, err)
+	}
+
+	log.DebugLog(ctx, "userID mapping metadata %s unset for %s", metadataKey, handler.logSubvolumeName)
+
+	return nil
 }
 
 // fenceNode attempts to fence a client node from accessing the CephFS subvolume.

--- a/internal/cephfs/core/metadata.go
+++ b/internal/cephfs/core/metadata.go
@@ -31,6 +31,10 @@ const (
 	// clientAddressKey is the key used to store the client address.
 	// starts with `.` to avoid copying it to the mirrored subvolume.
 	clientAddressKey = ".cephfs.csi.ceph.com/clientaddress"
+
+	// userIdMappingKey is the key used to store the userID mapping.
+	// starts with `.` to avoid copying it to the mirrored subvolume.
+	userIdMappingKey = ".cephfs.csi.ceph.com/userid"
 )
 
 // ErrSubVolMetadataNotSupported is returned when set/get/list/remove subvolume metadata options are not supported.
@@ -40,6 +44,12 @@ var ErrSubVolMetadataNotSupported = errors.New("subvolume metadata operations ar
 // subvolume metadata.
 func GetClientAddressKey(volumeId, nodeId string) string {
 	return fmt.Sprintf("%s/%s/%s", clientAddressKey, volumeId, nodeId)
+}
+
+// GetUserIDMappingKey returns the key to store the user ID mapping in the
+// subvolume metadata.
+func GetUserIDMappingKey(volumeID, nodeID string) string {
+	return fmt.Sprintf("%s/%s/%s", userIdMappingKey, volumeID, nodeID)
 }
 
 func (s *subVolumeClient) supportsSubVolMetadata() bool {

--- a/internal/cephfs/driver.go
+++ b/internal/cephfs/driver.go
@@ -168,6 +168,7 @@ func (fs *Driver) Run(conf *util.Config) {
 			conf.KernelMountOptions, conf.FuseMountOptions,
 			nodeLabels, topology, crushLocationMap,
 		)
+		fs.ns.setMetadata = true
 	}
 
 	if conf.IsControllerServer {

--- a/internal/cephfs/nodeserver.go
+++ b/internal/cephfs/nodeserver.go
@@ -53,6 +53,9 @@ type NodeServer struct {
 	kernelMountOptions string
 	fuseMountOptions   string
 	healthChecker      hc.Manager
+
+	// set metadata on volume
+	setMetadata bool
 }
 
 func getCredentialsForVolume(
@@ -274,6 +277,11 @@ func (ns *NodeServer) NodeStageVolume(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
+	err = ns.setUserIdMapping(ctx, req.GetSecrets(), req.GetVolumeId(), volOptions)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	err = ns.setClientAddress(ctx, req.GetVolumeId(), req.GetSecrets(), volOptions)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -331,6 +339,58 @@ func (ns *NodeServer) NodeStageVolume(
 	ns.startSharedHealthChecker(ctx, req.GetVolumeId(), stagingTargetPath)
 
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// setUserIdMapping sets the user ID mapping in the CephFS subvolume metadata.
+// The user ID is the ceph user used for mounting the subvolume.
+// If the volume is a snapshot-backed, the user ID mapping is set on the backing snapshot metadata.
+// If the '--setmetadata' flag is set to false in CSI driver configuration or if the volume is static it does nothing.
+func (ns *NodeServer) setUserIdMapping(
+	ctx context.Context, secrets map[string]string,
+	volumeId string, volOptions *store.VolumeOptions,
+) error {
+	if !ns.setMetadata || !volOptions.ProvisionVolume {
+		return nil
+	}
+
+	conn := volOptions.GetConnection()
+	subvolumeClient := core.NewSubVolume(conn, &volOptions.SubVolume, volOptions.ClusterID, "", true)
+	metadataKey := core.GetUserIDMappingKey(volumeId, ns.Driver.GetNodeID())
+	params := map[string]string{metadataKey: conn.Creds.ID}
+
+	if volOptions.BackingSnapshot {
+		cr, err := util.NewAdminCredentials(secrets)
+		if err != nil {
+			return fmt.Errorf("failed to create credentials from secrets: %w", err)
+		}
+		defer cr.DeleteCredentials()
+
+		volOpt, _, sid, err := store.NewSnapshotOptionsFromID(ctx, volOptions.BackingSnapshotID, cr, secrets, "", true)
+		if err != nil {
+			return err
+		}
+		defer volOpt.Destroy()
+		snapClient := core.NewSnapshot(conn, sid.FsSnapshotName, volOpt.ClusterID, "", true, &volOpt.SubVolume)
+		if err = snapClient.SetAllSnapshotMetadata(params); err != nil {
+			return fmt.Errorf("failed to set user ID mapping metadata %s for subvolume snapshot %s: %w",
+				metadataKey, sid.FsSnapshotName, err)
+		}
+
+		log.DebugLog(ctx, "userID mapping metadata %s set for subvolume snapshot %s",
+			metadataKey, sid.FsSnapshotName)
+
+		return nil
+	}
+
+	err := subvolumeClient.SetAllMetadata(params)
+	if err != nil {
+		return fmt.Errorf("failed to set user ID mapping %s for subvolume %s: %w",
+			metadataKey, volOptions.SubVolume.VolID, err)
+	}
+
+	log.DebugLog(ctx, "userID mapping metadata %s set for subvolume %s", metadataKey, volOptions.SubVolume.VolID)
+
+	return nil
 }
 
 // setClientAddress extracts the client IP address and stores it in the subvolume metadata.

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -1855,12 +1855,49 @@ func (cs *ControllerServer) ControllerUnpublishVolume(
 	}
 	defer rv.Destroy(ctx)
 
+	err = cs.removeUserIdMapping(ctx, req.GetNodeId(), rv)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to remove user ID mapping for node %s: %v", req.GetNodeId(), err)
+	}
+
 	err = cs.fenceNode(ctx, req.GetNodeId(), rv, credentials)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to fence node %s: %v", req.GetNodeId(), err)
 	}
 
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}
+
+// removeUserIdMapping attempts to remove nodeId:userId mapping in metadata the RBD volume.
+//
+// Parameters:
+//   - nodeId: The ID of the node that we want to remove the user ID mapping for.
+//   - rbdVolume: The rbdVolume object representing the RBD image.
+//
+// Behavior:
+//   - If the '--setmetadata' flag is set to false in CSI driver configuration, does nothing.
+//   - Removes the user ID mapping metadata for the specified nodeId from the RBD image.
+func (cs *ControllerServer) removeUserIdMapping(
+	ctx context.Context,
+	nodeId string,
+	rv *rbdVolume,
+) error {
+	if !cs.SetMetadata {
+		return nil
+	}
+	if nodeId == "" {
+		return errors.New("nodeId cannot be empty")
+	}
+
+	metadataKey := getUserIDMappingKey(rv.VolID, nodeId)
+	err := rv.RemoveMetadata(metadataKey)
+	if err != nil && !errors.Is(err, librbd.ErrNotExist) {
+		return fmt.Errorf("failed to remove user ID mapping for node %s on image %s: %w", nodeId, rv, err)
+	}
+
+	log.DebugLog(ctx, "successfully removed user ID mapping for nodeId %s", nodeId)
+
+	return nil
 }
 
 // fenceNode attempts to fence a client node from accessing the RBD volume.

--- a/internal/rbd/driver/driver.go
+++ b/internal/rbd/driver/driver.go
@@ -164,7 +164,7 @@ func (r *Driver) Run(conf *util.Config) {
 			log.FatalLogMsg("%v", err.Error())
 		}
 		r.ns = NewNodeServer(r.cd, conf.Vtype, nodeLabels, topology, crushLocationMap)
-
+		r.ns.SetMetadata = conf.SetMetadata
 		var attr string
 		attr, err = rbd.GetKrbdSupportedFeatures()
 		if err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/rbd/nodeserver.go
+++ b/internal/rbd/nodeserver.go
@@ -55,6 +55,9 @@ type NodeServer struct {
 	ext4HasPrezeroedSupport featureFlag
 	// xfsHasReflinkSupport indicates whether the xfs filesystem has support for reflink.
 	xfsHasReflinkSupport featureFlag
+
+	// set metadata on volume
+	SetMetadata bool
 }
 
 // stageTransaction struct represents the state a transaction was when it either completed
@@ -398,6 +401,11 @@ func (ns *NodeServer) NodeStageVolume(
 
 		return &csi.NodeStageVolumeResponse{}, nil
 	}
+	// Set UserId mapping in the image metadata
+	err = ns.setUserIdMapping(ctx, cr, rv, isStaticVol)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to set userId mapping for %s: %v", rv, err)
+	}
 
 	// Set ClientAddress in the image metadata
 	err = ns.setClientAddress(ctx, cr, rv, isStaticVol)
@@ -430,6 +438,29 @@ func (ns *NodeServer) NodeStageVolume(
 		stagingTargetPath)
 
 	return &csi.NodeStageVolumeResponse{}, nil
+}
+
+// setUserIdMapping sets the user ID mapping in the RBD image metadata.
+// The user ID is the ceph user used for mounting the RBD image.
+// If the '--setmetadata' flag is set to false in CSI driver configuration or if the volume is static
+// this function does nothing.
+func (ns *NodeServer) setUserIdMapping(
+	ctx context.Context, cr *util.Credentials, rv *rbdVolume, isStaticVol bool,
+) error {
+	if !ns.SetMetadata || isStaticVol {
+		return nil
+	}
+
+	nodeId := ns.Driver.GetNodeID()
+	metadataKey := getUserIDMappingKey(rv.VolID, nodeId)
+	err := rv.SetMetadata(metadataKey, cr.ID)
+	if err != nil {
+		return fmt.Errorf("failed to set client address for %s: %w", rv, err)
+	}
+
+	log.DebugLog(ctx, "user ID mapping %s set in metadata for image %s", metadataKey, rv)
+
+	return nil
 }
 
 // setClientAddress extracts the client IP address and stores it in the RBD image metadata.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -91,6 +91,10 @@ const (
 	// starts with `.` to avoid copying it to the mirrored image.
 	clientAddressKey = ".rbd.csi.ceph.com/clientaddress"
 
+	// userIdMappingKey is the key used to store the userID mapping.
+	// starts with `.` to avoid copying it to the mirrored image.
+	userIdMappingKey = ".rbd.csi.ceph.com/userid"
+
 	// Suffix added to the temp cloned image name.
 	// This will always be (rbd image name + "-temp").
 	tempImageSuffix = "-temp"
@@ -289,6 +293,11 @@ var (
 // getClientAddressKey returns the key for storing client address metadata for a specific node.
 func getClientAddressKey(volumeId, nodeId string) string {
 	return fmt.Sprintf("%s/%s/%s", clientAddressKey, volumeId, nodeId)
+}
+
+// getUserIDMappingKey returns the key for storing user ID mapping metadata for a specific node.
+func getUserIDMappingKey(volumeID, nodeID string) string {
+	return fmt.Sprintf("%s/%s/%s", userIdMappingKey, volumeID, nodeID)
 }
 
 // prepareKrbdFeatureAttrs prepare krbd fearure set based on kernel version.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Without a mechanism to track nodeID:userID mappings per volume, it becomes challenging to:

Monitor which userIDs are actively being used across the cluster
Make informed decisions about key rotation, allowing safe cleanup of old keys

## Proposed Solution
The solution involves tracking userID information by storing it in the metadata of RBD images and CephFS subvolumes using the key: `.[rbd|cephfs].csi.ceph.com/userID/<NodeId>:<userID>`

**Checklist:**

* [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
