### PR TITLE
[DOWNSTREAM_ONLY] DFBUGS-3954: [release-4.20] rbd: add schedule again during group modification

### DIFF
--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ceph/ceph-csi/internal/util/log"
 
 	librbd "github.com/ceph/go-ceph/rbd"
+	"github.com/ceph/go-ceph/rbd/admin"
 	"github.com/csi-addons/spec/lib/go/replication"
 	"github.com/csi-addons/spec/lib/go/volumegroup"
 	"google.golang.org/grpc"
@@ -612,6 +613,22 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 		log.ErrorLog(ctx, "failed to enable mirroring after modifying volume group")
 
 		return nil, getGRPCError(err)
+	}
+
+	// Need to add scheduling again since disabling mirroring may have
+	// removed snapshot schedule too.
+	interval, startTime := getSchedulingDetails(req.GetParameters())
+	if interval != admin.NoInterval {
+		err = mirror.AddSnapshotScheduling(interval, startTime)
+		if err != nil {
+			return nil, err
+		}
+		log.DebugLog(
+			ctx,
+			"Added scheduling at interval %s, start time %s for group %s",
+			interval,
+			startTime,
+			vg)
 	}
 
 	csiVG, err := vg.ToCSI(ctx)


### PR DESCRIPTION
add the group snapshot schedule again after disabling/enabling mirroring as there might be a race condition when the snapshot scheduler might be run at the same time when the group is disabled which will remove the schedule for the group.
Therefore, we should re-add the schedule to avoid such a scenario.