### PR TITLE
[release:420]: fix: cyclomatic complexity golangci-lint failure

### DIFF
--- a/internal/csi-addons/rbd/replication.go
+++ b/internal/csi-addons/rbd/replication.go
@@ -508,6 +508,8 @@ func (rs *ReplicationServer) PromoteVolume(ctx context.Context,
 // volumeID, If the image is present, mirroring is enabled and the
 // image is in promoted state it will demote the volume as secondary.
 // If the image is already secondary it will return success.
+//
+//nolint:gocyclo,cyclop // TODO: reduce complexity
 func (rs *ReplicationServer) DemoteVolume(ctx context.Context,
 	req *replication.DemoteVolumeRequest,
 ) (*replication.DemoteVolumeResponse, error) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

golangci-lint complaints about cyclomatic complexity 21 of func `(*ReplicationServer).DemoteVolume` is high (> 20) (gocyclo).

Adding a //nolint:gocyclo,cyclop to the DemoteVolume func for now.