### PR TITLE
DFBUGS-2847: [release-4.19] rbd: flattenClonedRbdImages() may require namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
-replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5
+replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20251006122835-81e0726e7848
 
 require (
 	// sigs.k8s.io/controller-runtime wants this version, it gets replaced below

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5 h1:OZaxewnZ8Fu+taUkFl4Fl4VEMtDlVLDhShyPUObnNmk=
-github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5/go.mod h1:V++4AyPoTN50AtoHAZQ63lN0galqGLFE1b7aS0gO1Es=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20251006122835-81e0726e7848 h1:LJgdRRZLUwga7ZE5k8zKv6dWOoggZGPA6U8zg/TXeW0=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20251006122835-81e0726e7848/go.mod h1:V++4AyPoTN50AtoHAZQ63lN0galqGLFE1b7aS0gO1Es=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -634,6 +634,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			children,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {
@@ -669,6 +670,7 @@ func flattenTemporaryClonedImages(ctx context.Context, rbdVol *rbdVolume, cr *ut
 			children,
 			rbdVol.Pool,
 			rbdVol.Monitors,
+			rbdVol.RadosNamespace,
 			rbdVol.RbdImageName,
 			cr)
 		if err != nil {

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -824,12 +824,13 @@ func (ri *rbdImage) getCloneDepth(ctx context.Context) (uint, error) {
 func flattenClonedRbdImages(
 	ctx context.Context,
 	children []string,
-	pool, monitors, rbdImageName string,
+	pool, monitors, radosNamespace, rbdImageName string,
 	cr *util.Credentials,
 ) error {
 	rv := &rbdVolume{}
 	rv.Monitors = monitors
 	rv.Pool = pool
+	rv.RadosNamespace = radosNamespace
 	rv.RbdImageName = rbdImageName
 
 	defer rv.Destroy(ctx)

--- a/vendor/github.com/ceph/go-ceph/cephfs/file.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/file.go
@@ -7,6 +7,10 @@ package cephfs
 #include <stdlib.h>
 #include <fcntl.h>
 #include <cephfs/libcephfs.h>
+
+int _go_ceph_fchown(struct ceph_mount_info *cmount, int fd, uid_t uid, gid_t gid) {
+	return ceph_fchown(cmount, fd, uid, gid);
+}
 */
 import "C"
 
@@ -272,13 +276,13 @@ func (f *File) Fchmod(mode uint32) error {
 //
 // Implements:
 //
-//	int ceph_fchown(struct ceph_mount_info *cmount, int fd, int uid, int gid);
+//	int ceph_fchown(struct ceph_mount_info *cmount, int fd, uid_t uid, gid_t gid);
 func (f *File) Fchown(user uint32, group uint32) error {
 	if err := f.validate(); err != nil {
 		return err
 	}
 
-	ret := C.ceph_fchown(f.mount.mount, f.fd, C.int(user), C.int(group))
+	ret := C._go_ceph_fchown(f.mount.mount, f.fd, C.uid_t(user), C.gid_t(group))
 	return getError(ret)
 }
 

--- a/vendor/github.com/ceph/go-ceph/cephfs/permissions.go
+++ b/vendor/github.com/ceph/go-ceph/cephfs/permissions.go
@@ -5,6 +5,14 @@ package cephfs
 #cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
 #include <stdlib.h>
 #include <cephfs/libcephfs.h>
+
+int _go_ceph_chown(struct ceph_mount_info *cmount, const char *path, uid_t uid, gid_t gid) {
+	return ceph_chown(cmount, path, uid, gid);
+}
+
+int _go_ceph_lchown(struct ceph_mount_info *cmount, const char *path, uid_t uid, gid_t gid) {
+	return ceph_lchown(cmount, path, uid, gid);
+}
 */
 import "C"
 
@@ -26,7 +34,7 @@ func (mount *MountInfo) Chown(path string, user uint32, group uint32) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_chown(mount.mount, cPath, C.int(user), C.int(group))
+	ret := C._go_ceph_chown(mount.mount, cPath, C.uid_t(user), C.gid_t(group))
 	return getError(ret)
 }
 
@@ -35,6 +43,6 @@ func (mount *MountInfo) Lchown(path string, user uint32, group uint32) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_lchown(mount.mount, cPath, C.int(user), C.int(group))
+	ret := C._go_ceph_lchown(mount.mount, cPath, C.uid_t(user), C.gid_t(group))
 	return getError(ret)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,7 +195,7 @@ github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/rbd
 github.com/ceph/ceph-csi/api/deploy/ocp
-# github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e => github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5
+# github.com/ceph/go-ceph v0.32.1-0.20250307053135-38b9676b1d4e => github.com/red-hat-storage/go-ceph v0.32.1-0.20251006122835-81e0726e7848
 ## explicit; go 1.22
 github.com/ceph/go-ceph/cephfs
 github.com/ceph/go-ceph/cephfs/admin
@@ -1246,5 +1246,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 # github.com/ceph/ceph-csi/api => ./api
-# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20250425091651-2164276cc9e5
+# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20251006122835-81e0726e7848
 # k8s.io/client-go => k8s.io/client-go v0.32.2


### PR DESCRIPTION
flattenClonedRbdImages() requires namespace if it not the default one.


(cherry picked from commit b0eb42823f7ad95072ca82cd02f186d0736f678e)

