### PR TITLE
[release-4.19]: DFBUGS-4233: fix: handle different clusterID between mirroring clients.

### DIFF
--- a/internal/rbd/group/util.go
+++ b/internal/rbd/group/util.go
@@ -433,8 +433,9 @@ func (cvg *commonVolumeGroup) GetCreationTime(ctx context.Context) (*time.Time, 
 // volumegroups should continue based on the type of error encountered.
 //
 // It checks if the given error matches any of the following known errors:
-//   - ErrPoolNotFound: The rbd pool where the volumegroup/omap is expected doesn't exist.
-//   - ErrGroupNotFound: The volumegroup doesn't exist in the rbd pool.
+//   - util.ErrPoolNotFound: The rbd pool where the volumegroup/omap is expected doesn't exist.
+//   - util.ErrConfigNotFound: No configuration exists for the cluster ID associated with the volumegroup.
+//   - rbderrors.ErrGroupNotFound: The volumegroup doesn't exist in the rbd pool.
 //   - rados.ErrPermissionDenied: Permissions to access the pool is denied.
 //
 // If any of these errors are encountered, the function returns `true`, indicating
@@ -450,6 +451,7 @@ func ShouldRetryVolumeGroupGeneration(err error) bool {
 	}
 	// Continue searching for specific known errors
 	return (errors.Is(err, util.ErrPoolNotFound) ||
+		errors.Is(err, util.ErrConfigNotFound) ||
 		errors.Is(err, rbderrors.ErrGroupNotFound) ||
 		errors.Is(err, rados.ErrPermissionDenied))
 }

--- a/internal/rbd/group/util_test.go
+++ b/internal/rbd/group/util_test.go
@@ -47,7 +47,12 @@ func Test_shouldRetryVolumeGroupGeneration(t *testing.T) {
 			want: true, // Known error, continue searching
 		},
 		{
-			name: "ErrGroupNotFound (continue searching)",
+			name: "ErrConfigNotFound (continue searching)",
+			args: args{err: util.ErrConfigNotFound},
+			want: true, // Known error, continue searching
+		},
+		{
+			name: "ErrRBDGroupNotFound (continue searching)",
 			args: args{err: rbderrors.ErrGroupNotFound},
 			want: true, // Known error, continue searching
 		},

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1240,6 +1240,7 @@ func generateVolumeFromVolumeID(
 // It checks if the given error matches any of the following known errors:
 //   - util.ErrKeyNotFound: The key required to locate the volume is missing in Rados omap.
 //   - util.ErrPoolNotFound: The rbd pool where the volume/omap is expected doesn't exist.
+//   - util.ErrConfigNotFound: No configuration exists for the cluster ID associated with the volume.
 //   - ErrImageNotFound: The image doesn't exist in the rbd pool.
 //   - rados.ErrPermissionDenied: Permissions to access the pool is denied.
 //
@@ -1257,6 +1258,7 @@ func ShouldRetryVolumeGeneration(err error) bool {
 	// Continue searching for specific known errors
 	return (errors.Is(err, util.ErrKeyNotFound) ||
 		errors.Is(err, util.ErrPoolNotFound) ||
+		errors.Is(err, util.ErrConfigNotFound) ||
 		errors.Is(err, rbderrors.ErrImageNotFound) ||
 		errors.Is(err, rados.ErrPermissionDenied))
 }

--- a/internal/rbd/rbd_util_test.go
+++ b/internal/rbd/rbd_util_test.go
@@ -418,6 +418,11 @@ func Test_shouldRetryVolumeGeneration(t *testing.T) {
 			want: true, // Known error, continue searching
 		},
 		{
+			name: "ErrConfigNotFound (continue searching)",
+			args: args{err: util.ErrConfigNotFound},
+			want: true, // Known error, continue searching
+		},
+		{
 			name: "ErrImageNotFound (continue searching)",
 			args: args{err: rbderrors.ErrImageNotFound},
 			want: true, // Known error, continue searching

--- a/internal/util/csiconfig.go
+++ b/internal/util/csiconfig.go
@@ -83,7 +83,7 @@ func readClusterInfo(pathToConfig, clusterID string) (*kubernetes.ClusterInfo, e
 		}
 	}
 
-	return nil, fmt.Errorf("missing configuration for cluster ID %q", clusterID)
+	return nil, fmt.Errorf("%w: %q", ErrConfigNotFound, clusterID)
 }
 
 // Mons returns a comma separated MON list from the csi config for the given clusterID.

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -34,4 +34,6 @@ var (
 	ErrClusterIDNotSet = errors.New("clusterID must be set")
 	// ErrMissingConfigForMonitor is returned when clusterID is not found for the mon.
 	ErrMissingConfigForMonitor = errors.New("missing configuration of cluster ID for monitor")
+	// ErrConfigNotFound is returned when no configuration is found for a cluster ID.
+	ErrConfigNotFound = errors.New("missing configuration for cluster ID")
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

Problem:

```
$ k -n $n logs openshift-storage.rbd.csi.ceph.com-ctrlplugin-7ccc854b4b-l4m4f csi-rbdplugin | grep "ID: 1580"
I0925 06:51:40.486621       1 utils.go:271] ID: 1580 Req-ID: 0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced GRPC call: /replication.Controller/EnableVolumeReplication
I0925 06:51:40.486705       1 utils.go:272] ID: 1580 Req-ID: 0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced GRPC request: {"parameters":{"clusterID":"ded25f3d-6daa-41f9-923c-9d1fb7f9a35d","mirroringMode":"snapshot","schedulingInterval":"5m"},"replication_source":{"volume":{"volume_id":"0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced"}},"secrets":"***stripped***"}
E0925 06:51:40.487048       1 rbd_util.go:1167] ID: 1580 Req-ID: 0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced failed getting mons (failed to fetch monitor list using clusterID (7d46eaf1-71e5-43f7-96c5-54178f8079b1): missing configuration for cluster ID "7d46eaf1-71e5-43f7-96c5-54178f8079b1")
E0925 06:51:40.487080       1 replication.go:286] ID: 1580 Req-ID: 0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced failed to get mirror source with id "0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced": failed to get volume by id "0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced": failed to get volume from id "0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced": failed to fetch monitor list using clusterID (7d46eaf1-71e5-43f7-96c5-54178f8079b1): missing configuration for cluster ID "7d46eaf1-71e5-43f7-96c5-54178f8079b1"
E0925 06:51:40.487133       1 utils.go:276] ID: 1580 Req-ID: 0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced GRPC error: rpc error: code = Internal desc = failed to get volume by id "0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced": failed to get volume from id "0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced": failed to fetch monitor list using clusterID (7d46eaf1-71e5-43f7-96c5-54178f8079b1): missing configuration for cluster ID "7d46eaf1-71e5-43f7-96c5-54178f8079b1"
```

The clusterID for bm5-c1 is `ded25f3d-6daa-41f9-923c-9d1fb7f9a35d` and the EnableVolumeReplication for VolumeHandle `0001-0024-7d46eaf1-71e5-43f7-96c5-54178f8079b1-000000000000000a-f5fdbe99-d873-4861-a1e3-b5240c330ced`  (encoded clusterID: `7d46eaf1-71e5-43f7-96c5-54178f8079b1` is from remote cluster) fails since there is no configuration for the remote clusterID in config.json.

---

<details>
<summary>Show available bot commands</summary>

These commands are normally not required, but in case of issues, leave any of
the following bot commands in an otherwise empty comment in this PR:

* `/retest ci/centos/<job-name>`: retest the `<job-name>` after unrelated
  failure (please report the failure too!)

</details>
