### PR TITLE
[release-4.19] [DOWNSTREAM_ONLY] ci: update custom tag for ceph cg support

### DIFF
--- a/build.env
+++ b/build.env
@@ -22,7 +22,7 @@ CSI_UPGRADE_VERSION=v3.13.1
 CEPH_CSI_OPERATOR_VERSION=latest
 
 # Ceph version to use
-BASE_IMAGE=quay.ceph.io/ceph-ci/ceph:wip-pkalever-rbd-group-snap-mirror
+BASE_IMAGE=quay.ceph.io/ceph-ci/ceph:wip-rbd-cgsm-base
 CEPH_VERSION=squid
 
 # standard Golang options

--- a/scripts/Dockerfile.test
+++ b/scripts/Dockerfile.test
@@ -7,7 +7,7 @@
 # Operating System, so generated binaries and versions of dependencies may be a
 # little different.
 #
-FROM quay.ceph.io/ceph-ci/ceph:wip-pkalever-rbd-group-snap-mirror
+FROM quay.ceph.io/ceph-ci/ceph:wip-rbd-cgsm-base
 
 ARG GOPATH=/go
 ARG GOROOT=/usr/local/go


### PR DESCRIPTION
This is a manual cherry-pick of #622 
And, also a the fix for CI failure.