### PR TITLE
DFBUGS-4063: [release-4.19]: cephfs: skip reset quiesce during DeleteVolumeGroupSnapshot

### DIFF
--- a/internal/cephfs/core/quiesce.go
+++ b/internal/cephfs/core/quiesce.go
@@ -80,6 +80,8 @@ type FSQuiesceClient interface {
 	) (*admin.QuiesceInfo, error)
 }
 
+type FSQuiesceClientMap map[string]FSQuiesceClient
+
 type Volume struct {
 	VolumeID  string
 	ClusterID string

--- a/internal/cephfs/core/quiesce.go
+++ b/internal/cephfs/core/quiesce.go
@@ -82,6 +82,9 @@ type FSQuiesceClient interface {
 
 type FSQuiesceClientMap map[string]FSQuiesceClient
 
+// EmptyFSQuiesceClientMap is used when no filesystem quiesce operations are needed.
+var EmptyFSQuiesceClientMap = FSQuiesceClientMap{}
+
 type Volume struct {
 	VolumeID  string
 	ClusterID string

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -190,7 +190,7 @@ func (cs *ControllerServer) CreateVolumeGroupSnapshot(
 // CreateVolumeGroupSnapshotRequest.
 func (cs *ControllerServer) queisceFileSystems(ctx context.Context,
 	vgs *store.VolumeGroupSnapshotIdentifier,
-	fsMap map[string]core.FSQuiesceClient,
+	fsMap core.FSQuiesceClientMap,
 ) (bool, error) {
 	var inProgress bool
 	for _, fm := range fsMap {
@@ -219,7 +219,7 @@ func (cs *ControllerServer) releaseQuiesceAndGetVolumeGroupSnapshotResponse(
 	ctx context.Context,
 	req *csi.CreateVolumeGroupSnapshotRequest,
 	vgs *store.VolumeGroupSnapshotIdentifier,
-	fsMap map[string]core.FSQuiesceClient,
+	fsMap core.FSQuiesceClientMap,
 	vg *store.VolumeGroupOptions,
 	cr *util.Credentials,
 ) (*csi.CreateVolumeGroupSnapshotResponse, error) {
@@ -312,7 +312,7 @@ func (cs *ControllerServer) createSnapshotAddToVolumeGroupJournal(
 	vgo *store.VolumeGroupOptions,
 	vgs *store.VolumeGroupSnapshotIdentifier,
 	cr *util.Credentials,
-	fsMap map[string]core.FSQuiesceClient) (
+	fsMap core.FSQuiesceClientMap) (
 	[]*csi.CreateSnapshotResponse,
 	error,
 ) {
@@ -376,7 +376,7 @@ func formatCreateSnapshotRequest(volID, groupSnapshotName,
 // CreateVolumeGroupSnapshotRequest.
 func releaseFSQuiesce(ctx context.Context,
 	requestName string,
-	fsMap map[string]core.FSQuiesceClient,
+	fsMap core.FSQuiesceClientMap,
 ) error {
 	inProgress := false
 	var err error
@@ -407,7 +407,7 @@ func releaseFSQuiesce(ctx context.Context,
 // CreateVolumeGroupSnapshotRequest.
 func fsQuiesceWithExpireTimeout(ctx context.Context,
 	requestName string,
-	fsMap map[string]core.FSQuiesceClient,
+	fsMap core.FSQuiesceClientMap,
 ) error {
 	var err error
 
@@ -498,7 +498,7 @@ func checkIfFSNeedQuiesceRelease(vgs *store.VolumeGroupSnapshotIdentifier, volID
 }
 
 // getClusterIDForVolumeID gets the clusterID for the volumeID from the fms map.
-func getClusterIDForVolumeID(fms map[string]core.FSQuiesceClient, volumeID string) string {
+func getClusterIDForVolumeID(fms core.FSQuiesceClientMap, volumeID string) string {
 	for _, fm := range fms {
 		for _, vol := range fm.GetVolumes() {
 			if vol.VolumeID == volumeID {
@@ -518,7 +518,7 @@ func getFsNamesAndSubVolumeFromVolumeIDs(ctx context.Context,
 	secret map[string]string,
 	volIDs []string,
 	cr *util.Credentials) (
-	map[string]core.FSQuiesceClient,
+	core.FSQuiesceClientMap,
 	error,
 ) {
 	type fs struct {
@@ -561,7 +561,7 @@ func getFsNamesAndSubVolumeFromVolumeIDs(ctx context.Context,
 			volOptions.SubVolume.VolID)
 		fm[uniqueName] = val
 	}
-	fsk := map[string]core.FSQuiesceClient{}
+	fsk := core.FSQuiesceClientMap{}
 	var err error
 	defer func() {
 		if err != nil {
@@ -586,7 +586,7 @@ func getFsNamesAndSubVolumeFromVolumeIDs(ctx context.Context,
 }
 
 // destroyFSConnections destroys connections of all FSQuiesceClient.
-func destroyFSConnections(fsMap map[string]core.FSQuiesceClient) {
+func destroyFSConnections(fsMap core.FSQuiesceClientMap) {
 	for _, fm := range fsMap {
 		if fm != nil {
 			fm.Destroy()
@@ -611,7 +611,7 @@ func matchesSourceVolumeIDs(sourceVolumeIDs, volumeIDsInOMap []string) bool {
 func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Context,
 	vgs *store.VolumeGroupSnapshotIdentifier,
 	cr *util.Credentials,
-	fsMap map[string]core.FSQuiesceClient,
+	fsMap core.FSQuiesceClientMap,
 	secrets map[string]string,
 ) error {
 	// get the omap from the snapshot and volume mapping

--- a/internal/cephfs/groupcontrollerserver.go
+++ b/internal/cephfs/groupcontrollerserver.go
@@ -608,6 +608,10 @@ func matchesSourceVolumeIDs(sourceVolumeIDs, volumeIDsInOMap []string) bool {
 // volume group reservation. It also resets the quiesce of the subvolumes and
 // subvolume groups in the filesystems for the volumeID's present in the
 // CreateVolumeGroupSnapshotRequest.
+//
+// when fsMap is empty function will skip filesystem quiesce operations and
+// only perform snapshot deletion and reservation cleanup. This is the intended
+// behavior for DeleteVolumeGroupSnapshot operation where filesystem quiesce is not required.
 func (cs *ControllerServer) deleteSnapshotsAndUndoReservation(ctx context.Context,
 	vgs *store.VolumeGroupSnapshotIdentifier,
 	cr *util.Credentials,
@@ -735,22 +739,10 @@ func (cs *ControllerServer) DeleteVolumeGroupSnapshot(ctx context.Context,
 	}
 	vgo.Destroy()
 
-	volIds := vgsi.GetVolumeIDs()
-	fsMap, err := getFsNamesAndSubVolumeFromVolumeIDs(ctx, req.GetSecrets(), volIds, cr)
-	err = extractDeleteVolumeGroupError(err)
-	if err != nil {
-		log.ErrorLog(ctx, "failed to get volume group options: %v", err)
-		err = extractDeleteVolumeGroupError(err)
-		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
-
-		return &csi.DeleteVolumeGroupSnapshotResponse{}, nil
-	}
-
-	defer destroyFSConnections(fsMap)
-
-	err = cs.deleteSnapshotsAndUndoReservation(ctx, vgsi, cr, fsMap, req.GetSecrets())
+	// deleteSnapshotsAndUndoReservation will reset quiesce of the subvolumes.
+	// In case of DeleteVolumeGoupSnapshot, there is no need for quiesce at all.
+	// Passing empty fsMap, deleteSnapshotsAndUndoReservation will reset quiesce operation.
+	err = cs.deleteSnapshotsAndUndoReservation(ctx, vgsi, cr, core.EmptyFSQuiesceClientMap, req.GetSecrets())
 	if err != nil {
 		log.ErrorLog(ctx, "failed to delete snapshot and undo reservation: %v", err)
 		err = extractDeleteVolumeGroupError(err)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
Problem: deleteSnapshotsAndUndoReservation will reset quiesce
of the subvolumes. In case of DeleteVolumeGoupSnapshot,
there is no need for quiesce at all. Doing so, will result in
IO freeze.

This commit ensures to skip reset quiesce operation during
DeleteVolumeGroupSnapshot.
```

