### PR TITLE
DFBUGS-4350: [release-4.20] rbd: set creationTime while updating snapshot details

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1158,6 +1158,7 @@ func updateSnapshotDetails(ctx context.Context, rbdSnap *rbdSnapshot) error {
 		return err
 	}
 	rbdSnap.VolSize = vol.VolSize
+	rbdSnap.CreatedAt = vol.CreatedAt
 
 	return nil
 }


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch sets the `CreatedAt` field on the snapshot while calling `updateSnapshotDetails`.

This patch is DOWNSTREAM only as it will be encountered only when `LIST_SNAPSHOTS` RPC capability is advertised and the parent Image for the snapshot is in trash.
