### PR TITLE
DFBUGS-5033: [DOWNSTREAM_ONLY] rbd: retry volume group modification during promoting state

### DIFF
--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -447,11 +447,20 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 		}
 
 		log.DebugLog(ctx, "local status is %v and local state is %v", localStatus.IsUP(), localStatus.GetState())
-		if !vgrMirrorInfo.IsPrimary() ||
-			(localStatus.IsUP() && localStatus.GetState() != librbd.MirrorGroupStatusStateStopped.String()) {
-			log.DebugLog(ctx, "skipping modification of group, as it is in secondary/promoting state")
+		if !vgrMirrorInfo.IsPrimary() {
+			log.DebugLog(ctx, "skipping modification of group, as it is in secondary state")
 
 			return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
+		}
+
+		if vgrMirrorInfo.IsPrimary() && localStatus.IsUP() &&
+			localStatus.GetState() != librbd.MirrorGroupStatusStateStopped.String() {
+			log.ErrorLog(ctx, "can't modify group, as it is in promoting state")
+
+			return nil, status.Errorf(
+				codes.Internal,
+				"can't modify group, as it is in promoting state %q",
+				req.GetVolumeGroupId())
 		}
 
 		remoteSiteStatus, err := sts.GetRemoteSiteStatus(ctx)


### PR DESCRIPTION
If someone tries to modify the group while the group is being promoted, we should return error and retry the modification such that the group is modified when the group has been promoted. If we don't return an error, the caller might never retry the modification assuming the call was successful.

Ref: https://issues.redhat.com/browse/DFBUGS-5033