### PR TITLE
DFBUGS-5528: [release-4.20] util: disable informers on secrets

### DIFF
--- a/internal/util/k8s/secrets.go
+++ b/internal/util/k8s/secrets.go
@@ -155,6 +155,26 @@ func (sc *secretCache) updateCache(secret *corev1.Secret, force bool) map[string
 // It returns a map of key-value pairs contained in the Secret's data.
 // If the Secret does not exist or cannot be accessed, it returns an error.
 func GetSecret(secretName, secretNamespace string) (map[string]string, error) {
+	client, err := NewK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Kubernetes: %w", err)
+	}
+
+	secret, err := client.CoreV1().Secrets(secretNamespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret %q in namespace %q information: %w", secretName, secretNamespace, err)
+	}
+
+	secretData := make(map[string]string, len(secret.Data))
+	for k, v := range secret.Data {
+		secretData[k] = string(v)
+	}
+
+	return secretData, nil
+}
+
+// FIXME: Implement the secret cache in a manner that does not explode memory.
+func _(secretName, secretNamespace string) (map[string]string, error) {
 	// Start the watcher if not already running, only once
 	if cachedSecrets.running.CompareAndSwap(false, true) {
 		stopCh := make(chan struct{})


### PR DESCRIPTION
# Describe what this PR does #

This patch disables the secret cache which relied on Informers. As the informer was cluster scoped, it led to huge memory spikes due to decoding every secret.

The cache is disabled for it to be implemented in a better manner or to be removed entirely later.


(cherry picked from commit fb4fb8f0092136c8fce63b49d818deb134199c7e)
4.21 commit: 21d9d1d96a89911f99d84eaefacf6e66e80b9de1
4.22 commit: fb4fb8f0092136c8fce63b49d818deb134199c7e

