### PR TITLE
DFBUGS-5602: [release-4.21] The DR cluster fails to reach the Fenced state.

### DIFF
--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"time"
 
+	osdAdmin "github.com/ceph/go-ceph/common/admin/osd"
 	"github.com/ceph/go-ceph/rados"
 
 	"github.com/ceph/ceph-csi/internal/util/log"
@@ -301,11 +302,22 @@ func RemoveObject(ctx context.Context, monitors string, cr *Credentials, poolNam
 
 // AddCephBlocklist adds the IP to the Ceph blocklist.
 func AddCephBlocklist(ctx context.Context, monitors string, cr *Credentials, ip string, useRange bool) error {
-	arg := []string{
-		"--id=" + cr.ID,
-		"--keyfile=" + cr.KeyFile,
-		"-m=" + monitors,
+	conn := ClusterConnection{}
+	err := conn.Connect(monitors, cr)
+	if err != nil {
+		return fmt.Errorf("failed to connect to cluster: %w", err)
 	}
+	defer conn.Destroy()
+
+	blocklistAdmin, err := conn.GetOSDAdmin()
+	if err != nil {
+		return fmt.Errorf("failed to get osd admin for blocklisting: %w", err)
+	}
+
+	// When useRange is true, ip is already in CIDR format.
+	// When useRange is false, ip is a plain IP address.
+	// The go-ceph library automatically detects if it's a CIDR and adds "range" to the command.
+	clientAddr := ip
 
 	// TODO: add blocklist till infinity.
 	// Currently, ceph does not provide the functionality to blocklist IPs
@@ -313,17 +325,16 @@ func AddCephBlocklist(ctx context.Context, monitors string, cr *Credentials, ip 
 	// represent infinity from ceph-csi side.
 	// At any point in this time, the IPs can be unblocked by an UnfenceClusterReq.
 	// This needs to be updated once ceph provides functionality for the same.
-	cmd := []string{"osd", "blocklist"}
-	if useRange {
-		cmd = append(cmd, "range")
+	entry := osdAdmin.AddressEntry{
+		Addr:   clientAddr,
+		Expire: MaxBlocklistTime.Seconds(),
 	}
-	cmd = append(cmd, "add", ip, MaxBlocklistTime.String())
-	cmd = append(cmd, arg...)
-	_, stderr, err := ExecCommand(ctx, "ceph", cmd...)
+
+	err = blocklistAdmin.OSDBlocklistAdd(entry)
 	if err != nil {
-		return fmt.Errorf("failed to blocklist IP %q: %w stderr: %q", ip, err, stderr)
+		return fmt.Errorf("failed to blocklist IP %q: %w", clientAddr, err)
 	}
-	log.DebugLog(ctx, "blocklisted IP %q successfully", ip)
+	log.DebugLog(ctx, "blocklisted IP %q successfully", clientAddr)
 
 	return nil
 }
@@ -331,32 +342,41 @@ func AddCephBlocklist(ctx context.Context, monitors string, cr *Credentials, ip 
 // RemoveCephBlocklist removes the IP from the Ceph blocklist.
 // The value of nonce is ignored if useRange is true.
 func RemoveCephBlocklist(ctx context.Context, monitors string, cr *Credentials, ip, nonce string, useRange bool) error {
-	arg := []string{
-		"--id=" + cr.ID,
-		"--keyfile=" + cr.KeyFile,
-		"-m=" + monitors,
-	}
-
-	cmd := []string{"osd", "blocklist"}
-	if useRange {
-		cmd = append(cmd, "range")
-	}
-
-	// If nonce is not empty and we are not using
-	// range based blocks, we need to add the nonce
-	if nonce != "" && !useRange {
-		cmd = append(cmd, "rm", fmt.Sprintf("%s:0/%s", ip, nonce))
-	} else {
-		cmd = append(cmd, "rm", ip)
-	}
-
-	cmd = append(cmd, arg...)
-
-	_, stdErr, err := ExecCommand(ctx, "ceph", cmd...)
+	conn := ClusterConnection{}
+	err := conn.Connect(monitors, cr)
 	if err != nil {
-		return fmt.Errorf("failed to unblock IP %q: %v %w", ip, stdErr, err)
+		return fmt.Errorf("failed to connect to cluster: %w", err)
 	}
-	log.DebugLog(ctx, "unblocked IP %q successfully", ip)
+	defer conn.Destroy()
+
+	blocklistAdmin, err := conn.GetOSDAdmin()
+	if err != nil {
+		return fmt.Errorf("failed to get osd admin for blocklist removal: %w", err)
+	}
+
+	var clientAddr string
+	if useRange {
+		// When useRange is true, ip is already in CIDR format
+		clientAddr = ip
+	} else {
+		// If nonce is not empty and we are not using
+		// range based blocks, we need to add the nonce
+		if nonce != "" {
+			clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+		} else {
+			clientAddr = ip
+		}
+	}
+
+	entry := osdAdmin.AddressEntry{
+		Addr: clientAddr,
+	}
+
+	err = blocklistAdmin.OSDBlocklistRemove(entry)
+	if err != nil {
+		return fmt.Errorf("failed to unblock IP %q: %w", clientAddr, err)
+	}
+	log.DebugLog(ctx, "unblocked IP %q successfully", clientAddr)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

```
Replace direct CLI command execution with go-ceph library APIs for blocklist operations
in AddCephBlocklist and RemoveCephBlocklist functions.
```

Fixes below issues -
```
'rpc error: code = Internal desc = failed to fence CIDR block ["10.1.112.80/32
    10.1.112.50/32" "10.1.112.71/32" "10.1.112.51/32" "10.1.112.52/32" "10.1.112.70/32"]:
    failed to blocklist IP "10.1.112.80": an error (exit status 22) occurred while
    running ceph args: [osd blocklist add 10.1.112.80 43829h6m0s --id=csi-rbd-provisioner
    --keyfile=***stripped*** -m=10.1.112.84:3300,10.1.112.83:3300,10.1.112.87:3300,10.1.112.86:3300,10.1.112.82:3300]
    stderr: "43829h6m0s not valid:  43829h6m0s doesn''t represent a float\nInvalid
    command: unused arguments: [''43829h6m0s'']\nosd blocklist [<range>] <blocklistop:add|rm>
    <addr> [<expire:float>] :  add (optionally until <expire> seconds from now) or
    remove <addr> from blocklist\nError EINVAL: invalid command\n"'
  result: Failed
```

**Checklist:**

* [x]  **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#commit-messages).
* [x] Reviewed the developer guide on [Submitting a Pull Request](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#development-workflow)
* [ ] [Pending release notes](https://github.com/ceph/ceph-csi/blob/devel/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next major release.
* [ ] Documentation has been updated, if necessary.
* [ ] Unit tests have been added, if necessary.
* [ ] Integration tests have been added, if necessary.

---
```
I0212 12:34:31.312009       1 utils.go:350] ID: 32 GRPC call: /fence.FenceController/FenceClusterNetwork
I0212 12:34:31.312157       1 utils.go:351] ID: 32 GRPC request: {"cidrs":[{"cidr":"10.90.89.66/32"},{"cidr":"11.67.12.42/24"}],"parameters":{"clusterID":"rook-ceph"},"secrets":"***stripped***"}
I0212 12:34:32.307383       1 cephcmds.go:337] ID: 32 blocklisted IP "10.90.89.66/32" successfully
I0212 12:34:33.315575       1 cephcmds.go:337] ID: 32 blocklisted IP "11.67.12.42/24" successfully
I0212 12:34:33.315704       1 utils.go:357] ID: 32 GRPC response: {}

[root@c1 /]# ceph osd blocklist ls
cidr:11.67.12.42:0/24 2031-02-12T17:40:30.279345+0000
cidr:10.90.89.66:0/32 2031-02-12T17:40:29.981120+0000

I0212 12:36:50.953078       1 utils.go:350] ID: 35 GRPC call: /fence.FenceController/UnfenceClusterNetwork
I0212 12:36:50.953550       1 utils.go:351] ID: 35 GRPC request: {"cidrs":[{"cidr":"10.90.89.66/32"},{"cidr":"11.67.12.42/24"}],"parameters":{"clusterID":"rook-ceph"},"secrets":"***stripped***"}
I0212 12:36:51.206350       1 cephcmds.go:379] ID: 35 unblocked IP "10.90.89.66/32" successfully
I0212 12:36:52.210111       1 cephcmds.go:379] ID: 35 unblocked IP "11.67.12.42/24" successfully
I0212 12:36:52.211070       1 utils.go:357] ID: 35 GRPC response: {}

[root@c1 /]# ceph osd blocklist ls
listed 0 entries
```