### PR TITLE
[DOWNSTREAM_ONLY] DFBUGS-5115: [release-4.20] rbd: fix skipping modify if the group is promoting

### DIFF
--- a/internal/csi-addons/rbd/volumegroup.go
+++ b/internal/csi-addons/rbd/volumegroup.go
@@ -453,8 +453,8 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 			return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
 		}
 
-		if vgrMirrorInfo.IsPrimary() && localStatus.IsUP() &&
-			localStatus.GetState() != librbd.MirrorGroupStatusStateStopped.String() {
+		if vgrMirrorInfo.IsPrimary() && (!localStatus.IsUP() ||
+			localStatus.GetState() != librbd.MirrorGroupStatusStateStopped.String()) {
 			log.ErrorLog(ctx, "can't modify group, as it is in promoting state")
 
 			return nil, status.Errorf(
@@ -492,6 +492,7 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 	}
 
 	beforeVolumes, err := vg.ListVolumes(ctx)
+	defer destoryVolumes(ctx, beforeVolumes)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
@@ -500,19 +501,43 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 			err)
 	}
 
+	beforeVolumesInfo, err := vg.ListVolumesInGroup(ctx)
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to list volumes in volume group %q: %v",
+			vg,
+			err)
+	}
+
 	// beforeIDs contains the csiID as key, volume as value
 	beforeIDs := make(map[string]types.Volume, len(beforeVolumes))
+	// Only consider volume Ids that are present in the rbd group in the ceph backend.
 	for _, vol := range beforeVolumes {
-		id, idErr := vol.GetID(ctx)
-		if idErr != nil {
+		name, nameErr := vol.GetName(ctx)
+		if nameErr != nil {
 			return nil, status.Errorf(
 				codes.InvalidArgument,
-				"failed to get the CSI ID of volume %q: %v",
+				"failed to get the CSI Name of volume %q: %v",
 				vol,
-				idErr)
+				nameErr)
 		}
+		// Check if the volume is present in RBD Group in the ceph backend
+		found := slices.IndexFunc(beforeVolumesInfo, func(volInfo types.GroupImageInfo) bool {
+			return volInfo.GetName() == name
+		})
+		if found != -1 {
+			id, idErr := vol.GetID(ctx)
+			if idErr != nil {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"failed to get the CSI ID of volume %q: %v",
+					vol,
+					idErr)
+			}
 
-		beforeIDs[id] = vol
+			beforeIDs[id] = vol
+		}
 	}
 
 	// check which volumes should not be part of the group
@@ -534,6 +559,8 @@ func (vs *VolumeGroupServer) ModifyVolumeGroupMembership(
 
 	// Skip modification if there is no change to volumes list that are part of group
 	if len(toRemove) == 0 && len(toAdd) == 0 {
+		log.DebugLog(ctx, "skipping modification of group, as there are no changes to volumes in the group")
+
 		return &volumegroup.ModifyVolumeGroupMembershipResponse{}, nil
 	}
 

--- a/internal/rbd/group/volume_group.go
+++ b/internal/rbd/group/volume_group.go
@@ -377,6 +377,43 @@ func (vg *volumeGroup) ListVolumes(ctx context.Context) ([]types.Volume, error) 
 	return vg.volumes, nil
 }
 
+// groupImageInfo is a wrapper around librbd.GroupImageInfo that contains the
+// info of all the images part of the group.
+type groupImageInfo librbd.GroupImageInfo
+
+func (info groupImageInfo) GetName() string {
+	return info.Name
+}
+
+func (info groupImageInfo) GetPoolID() int64 {
+	return info.PoolID
+}
+
+func (vg *volumeGroup) ListVolumesInGroup(ctx context.Context) ([]types.GroupImageInfo, error) {
+	ioctx, err := vg.GetIOContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not get iocontext for volume group %q: %w", vg, err)
+	}
+
+	name, err := vg.GetName(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not get name for volume group %q: %w", vg, err)
+	}
+
+	imageList, err := librbd.GroupImageList(ioctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list images in volume group %q: %w", vg, err)
+	}
+
+	imageInfoList := make([]types.GroupImageInfo, len(imageList))
+
+	for i := range imageList {
+		imageInfoList[i] = groupImageInfo(imageList[i])
+	}
+
+	return imageInfoList, nil
+}
+
 // CreateSnapshots makes consistent snapshots of all the volumes in the volume group.
 func (vg *volumeGroup) CreateSnapshots(
 	ctx context.Context,

--- a/internal/rbd/types/group.go
+++ b/internal/rbd/types/group.go
@@ -48,6 +48,8 @@ type journalledObject interface {
 }
 
 // VolumeGroup contains a number of volumes.
+//
+//nolint:interfacebloat // VolumeGroup has more than 10 methods, that is ok.
 type VolumeGroup interface {
 	journalledObject
 
@@ -73,6 +75,9 @@ type VolumeGroup interface {
 
 	// ListVolumes returns a slice with all Volumes in the VolumeGroup.
 	ListVolumes(ctx context.Context) ([]Volume, error)
+
+	// ListVolumesInGroup returns a slice with all Volumes part of the VolumeGroup in RBD.
+	ListVolumesInGroup(ctx context.Context) ([]GroupImageInfo, error)
 
 	// CreateSnapshots creates Snapshots of all Volume in the VolumeGroup.
 	// The Snapshots are crash consistent, and created as a consistency

--- a/internal/rbd/types/mirror.go
+++ b/internal/rbd/types/mirror.go
@@ -115,3 +115,10 @@ type SyncInfo interface {
 	// syncing.
 	IsSyncing() bool
 }
+
+type GroupImageInfo interface {
+	// GetName returns the image name
+	GetName() string
+	// GetPoolID returns the poolID of the image
+	GetPoolID() int64
+}


### PR DESCRIPTION
We should skip modify if the status is down or state is not "stopped".

Also, added check to compare the volumes in the group using the "GroupImageList" api which returns the images
that are already part of the group in the backend. Only, if the group is not already modified in the backend we skip the group modification, else modify the group


(cherry picked from commit d9165ea8da9b3984fad8d215c1fc8be55add3c73)
