### PR TITLE
DFBUGS-5777: [release-4.22] util: optimize key rotation flow for cryptsetup

### DIFF
--- a/internal/util/cryptsetup/cryptsetup.go
+++ b/internal/util/cryptsetup/cryptsetup.go
@@ -39,6 +39,10 @@ const (
 	// Maximum time to wait for cryptsetup commands to complete.
 	ExecutionTimeout = 2*time.Minute + 30*time.Second
 
+	// Limit PBKDF parallel threads to 1 to reduce CPU contention
+	// when many cryptsetup processes run concurrently.
+	cryptsetupPBKDFParallelLimit = 1
+
 	// Limit memory used by Argon2i PBKDF to 32 MiB.
 	cryptsetupPBKDFMemoryLimit = 32 << 10 // 32768 KiB
 	luks2MetadataSize          = 32 << 7  // 4096 KiB
@@ -580,6 +584,8 @@ func (l *luksWrapper) Format(devicePath, passphrase string, cipherOptions *Encry
 		strconv.Itoa(luks2KeySlotsSize)+"k",
 		"--pbkdf-memory",
 		strconv.Itoa(cryptsetupPBKDFMemoryLimit),
+		"--pbkdf-parallel",
+		strconv.Itoa(cryptsetupPBKDFParallelLimit),
 		devicePath,
 		"-d",
 		"-")
@@ -635,6 +641,10 @@ func (l *luksWrapper) AddKey(devicePath, passphrase, newPassphrase, slot string)
 		"--verbose",
 		"--key-file="+passFile.Name(),
 		"--key-slot="+slot,
+		"--pbkdf-memory",
+		strconv.Itoa(cryptsetupPBKDFMemoryLimit),
+		"--pbkdf-parallel",
+		strconv.Itoa(cryptsetupPBKDFParallelLimit),
 		"luksAddKey",
 		devicePath,
 		newPassFile.Name(),
@@ -720,14 +730,17 @@ func (l *luksWrapper) VerifyKey(devicePath, passphrase, slot string) (bool, erro
 	}
 	defer os.Remove(keyFile.Name()) //nolint:errcheck // failed to delete temp file :-(
 
+	// Use "open --test-passphrase" instead of "luksChangeKey" to avoid
+	// an unnecessary PBKDF write derivation. --test-passphrase only
+	// derives the key once (read-only) to verify it matches the slot.
 	_, stderr, err := l.execCryptsetupCommand(
 		nil,
 		"--verbose",
 		"--key-file="+keyFile.Name(),
 		"--key-slot="+slot,
-		"luksChangeKey",
+		"open",
+		"--test-passphrase",
 		devicePath,
-		keyFile.Name(),
 	)
 	if err != nil {
 		// If the passphrase doesn't match the key in given slot


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

# Describe what this PR does #

This patch adds the missing memory limits to cryptsetup `AddKey`. If this limit is missing `cryptsetup` will determine its own limits in order to satisfy the KDF, which can lead to serious resource contentions, IOW, more power the system has, more resources will be used (this is intentional).

`Open` and `RemoveKey` use the memory limits(set when format/adding) from the existing headers on the device and hence do not require manual limits.

A limit on active threads is also enforced to run KDF on a single thread, reducing CPU contention when a lot of processes are active at the same time.

Additionally, use the `--test-passphrase` with `open` for verification instead of calling `changeKey` with same passphrase to save on unnecessary derivations and disk IO (test-passphrase is read only).


(cherry picked from commit 831466aeee06992d1ab74de14affccdfc866c7b8)


