### PR TITLE
DFBUGS-6838: [release-4.22] util: fix IPv6 address handling in blocklist operations

### DIFF
--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -521,7 +521,9 @@ func matchEntry(actual, expected string) bool {
 		actual = strings.TrimSuffix(actual, ":0/32")
 	} else {
 		// for ipv6 address, strip the :0/128 suffix if present
+		// Ceph returns IPv6 blocklist entries in bracket format: [fd98::9]:0/128
 		actual = strings.TrimSuffix(actual, ":0/128")
+		actual = strings.Trim(actual, "[]")
 	}
 
 	actualIP := net.ParseIP(actual)

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -232,11 +232,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(1 * time.Hour),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(1 * time.Hour),
 					},
 				},
@@ -250,11 +250,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 				},
@@ -268,11 +268,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 				},
@@ -286,11 +286,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 				},
@@ -336,11 +336,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now(),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now(),
 					},
 				},
@@ -354,11 +354,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::3:0/128",
+						Addr:  "[2001:db8::3]:0/128",
 						Until: time.Now(),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now(),
 					},
 				},
@@ -372,7 +372,7 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.MaxBlocklistTime),
 					},
 				},
@@ -426,25 +426,25 @@ func Test_matchEntry(t *testing.T) {
 		},
 		{
 			name:     "IPv6 match with /128 suffix",
-			actual:   "2001:db8::1:0/128",
+			actual:   "[2001:db8::1]:0/128",
 			expected: "2001:db8::1",
 			want:     true,
 		},
 		{
 			name:     "IPv6 match without /128 suffix",
-			actual:   "2001:db8::1:0/123213",
+			actual:   "[2001:db8::1]:0/123213",
 			expected: "2001:db8::1",
 			want:     false,
 		},
 		{
 			name:     "IPv6 no match different IPs",
-			actual:   "2001:db8::2:0/128",
+			actual:   "[2001:db8::2]:0/128",
 			expected: "2001:db8::1",
 			want:     false,
 		},
 		{
 			name:     "IPv6 compressed notation match",
-			actual:   "fd4a:ecbc:cafd:4e49::1:0/128",
+			actual:   "[fd4a:ecbc:cafd:4e49::1]:0/128",
 			expected: "fd4a:ecbc:cafd:4e49::1",
 			want:     true,
 		},

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"time"
@@ -355,14 +356,20 @@ func RemoveCephBlocklist(ctx context.Context, monitors string, cr *Credentials, 
 	}
 
 	var clientAddr string
+	//nolint:nestif // straightforward IPv4/IPv6 formatting with nonce
 	if useRange {
-		// When useRange is true, ip is already in CIDR format
 		clientAddr = ip
 	} else {
-		// If nonce is not empty and we are not using
-		// range based blocks, we need to add the nonce
 		if nonce != "" {
-			clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+			parsedIP := net.ParseIP(ip)
+			if parsedIP == nil {
+				return fmt.Errorf("failed to parse IP address %q", ip)
+			}
+			if parsedIP.To4() != nil {
+				clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+			} else {
+				clientAddr = fmt.Sprintf("[%s]:0/%s", ip, nonce)
+			}
 		} else {
 			clientAddr = ip
 		}


### PR DESCRIPTION
Ceph returns IPv6 blocklist entries in bracket format (e.g. [fd98::9]:0/128), but matchEntry did not strip brackets after removing the :0/128 suffix, causing net.ParseIP to fail and auto-unfence to silently skip all IPv6 entries.

Similarly, RemoveCephBlocklist formatted IPv6 addresses without brackets (fd98::9:0/0 instead of [fd98::9]:0/0), producing malformed addresses rejected by Ceph.

Fix matchEntry to strip brackets for IPv6, fix RemoveCephBlocklist to wrap IPv6 in brackets, and update test data to use real Ceph bracket format.

(cherry picked from commit c925e81f87627f81ab483c98a9804f61ea05f5b9)