### PR TITLE
DFBUGS-7322: [release-4.21] util: fix IPv6 address handling in blocklist operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
 
-replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20260109062642-357605f36918
+replace github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20260112083340-565356f9872c
 
 require (
 	// sigs.k8s.io/controller-runtime wants this version, it gets replaced below

--- a/go.sum
+++ b/go.sum
@@ -984,8 +984,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/red-hat-storage/go-ceph v0.32.1-0.20260109062642-357605f36918 h1:VKejmX760mMNppaAzYc+Svo+VAiTHtxCzEjFpPdTtxc=
-github.com/red-hat-storage/go-ceph v0.32.1-0.20260109062642-357605f36918/go.mod h1:3y2tOlITlyuVFhy8v6PpCEfjMwKPfXJiH0/2hKZZQRE=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20260112083340-565356f9872c h1:JlGqLIzSWyA6tA6L/oHZTPx6DFPDjTDRNtmzMw7/sYY=
+github.com/red-hat-storage/go-ceph v0.32.1-0.20260112083340-565356f9872c/go.mod h1:bXEbx2U9V/FNepxgJ1bnQtKaKeSnGr1MNFAMvz3NDkc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -589,14 +589,7 @@ func containsMatchingBlockListEntry(
 			continue
 		}
 
-		// Until is in ISO8601 format.
-		until, err := time.Parse(ISO8601TimeLayout, entry.Until)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse blocklist entry time %q: %w",
-				entry.Until, err)
-		}
-
-		timeLeftUntilExpire := time.Until(until)
+		timeLeftUntilExpire := time.Until(entry.Until)
 		// Check if the blocklist entry is eligible for auto-unfencing if
 		// 1. the time left until expiry is less than or equal to AutoBlocklistTime,
 		// 2. the blocklist was done at least blockListCoolDownPeriod seconds (5 Minutes) ago.

--- a/internal/csi-addons/networkfence/fencing.go
+++ b/internal/csi-addons/networkfence/fencing.go
@@ -628,7 +628,9 @@ func matchEntry(actual, expected string) bool {
 		actual = strings.TrimSuffix(actual, ":0/32")
 	} else {
 		// for ipv6 address, strip the :0/128 suffix if present
+		// Ceph returns IPv6 blocklist entries in bracket format: [fd98::9]:0/128
 		actual = strings.TrimSuffix(actual, ":0/128")
+		actual = strings.Trim(actual, "[]")
 	}
 
 	actualIP := net.ParseIP(actual)

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -279,11 +279,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "192.0.1.0:0/32",
-						Until: time.Now().Add(1 * time.Hour).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(1 * time.Hour),
 					},
 					{
 						Addr:  "192.0.2.0:0/32",
-						Until: time.Now().Add(1 * time.Hour).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(1 * time.Hour),
 					},
 				},
 				addr: "192.0.1.0",
@@ -297,11 +297,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "192.0.1.0:0/32",
-						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 					{
 						Addr:  "192.0.2.0:0/32",
-						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 				},
 				addr: "192.0.1.0",
@@ -315,11 +315,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "192.0.1.0:0/32",
-						Until: time.Now().Add(util.AutoBlocklistTime).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 					{
 						Addr:  "192.0.2.0:0/32",
-						Until: time.Now().Add(util.AutoBlocklistTime).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 				},
 				addr: "192.0.1.0",
@@ -332,14 +332,12 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr: "192.0.1.0:0/32",
-						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute).
-							Format(ISO8601TimeLayout),
+						Addr:  "192.0.1.0:0/32",
+						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 					{
-						Addr: "192.0.2.0:0/32",
-						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute).
-							Format(ISO8601TimeLayout),
+						Addr:  "192.0.2.0:0/32",
+						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 				},
 				addr: "192.0.1.0",
@@ -353,11 +351,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "2001:db8::1:0/128",
-						Until: time.Now().Add(1 * time.Hour).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(1 * time.Hour),
 					},
 					{
 						Addr:  "2001:db8::2:0/128",
-						Until: time.Now().Add(1 * time.Hour).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(1 * time.Hour),
 					},
 				},
 				addr: "2001:db8::1",
@@ -371,11 +369,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "2001:db8::1:0/128",
-						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 					{
 						Addr:  "2001:db8::2:0/128",
-						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 				},
 				addr: "2001:db8::1",
@@ -389,11 +387,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "2001:db8::1:0/128",
-						Until: time.Now().Add(util.AutoBlocklistTime).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 					{
 						Addr:  "2001:db8::2:0/128",
-						Until: time.Now().Add(util.AutoBlocklistTime).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 				},
 				addr: "2001:db8::1",
@@ -406,14 +404,12 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr: "2001:db8::1:0/128",
-						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute).
-							Format(ISO8601TimeLayout),
+						Addr:  "2001:db8::1:0/128",
+						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 					{
-						Addr: "2001:db8::2:0/128",
-						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute).
-							Format(ISO8601TimeLayout),
+						Addr:  "2001:db8::2:0/128",
+						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 				},
 				addr: "2001:db8::1",
@@ -427,11 +423,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "193.0.1.0:0/32",
-						Until: time.Now().Format(ISO8601TimeLayout),
+						Until: time.Now(),
 					},
 					{
 						Addr:  "192.0.2.0:0/32",
-						Until: time.Now().Format(ISO8601TimeLayout),
+						Until: time.Now(),
 					},
 				},
 				addr: "192.0.1.0",
@@ -445,7 +441,7 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "192.0.1.0:0/32",
-						Until: time.Now().Add(util.MaxBlocklistTime).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.MaxBlocklistTime),
 					},
 				},
 				addr: "192.0.1.0",
@@ -454,30 +450,16 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Until is not in ISO8601 format",
-			args: args{
-				blocklist: &[]osdAdmin.Blocklist{
-					{
-						Addr:  "192.0.1.0:0/32",
-						Until: time.Now().Format(time.RFC3339),
-					},
-				},
-				addr: "192.0.1.0",
-			},
-			want:    false,
-			wantErr: true,
-		},
-		{
 			name: "matching IPv6 entry found",
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "2001:db8::1:0/128",
-						Until: time.Now().Format(ISO8601TimeLayout),
+						Until: time.Now(),
 					},
 					{
 						Addr:  "2001:db8::2:0/128",
-						Until: time.Now().Format(ISO8601TimeLayout),
+						Until: time.Now(),
 					},
 				},
 				addr: "2001:db8::1",
@@ -491,11 +473,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "2001:db8::3:0/128",
-						Until: time.Now().Format(ISO8601TimeLayout),
+						Until: time.Now(),
 					},
 					{
 						Addr:  "2001:db8::2:0/128",
-						Until: time.Now().Format(ISO8601TimeLayout),
+						Until: time.Now(),
 					},
 				},
 				addr: "2001:db8::1",
@@ -509,27 +491,13 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 				blocklist: &[]osdAdmin.Blocklist{
 					{
 						Addr:  "2001:db8::1:0/128",
-						Until: time.Now().Add(util.MaxBlocklistTime).Format(ISO8601TimeLayout),
+						Until: time.Now().Add(util.MaxBlocklistTime),
 					},
 				},
 				addr: "2001:db8::1",
 			},
 			want:    false,
 			wantErr: false,
-		},
-		{
-			name: "IPv6 Until is not in ISO8601 format",
-			args: args{
-				blocklist: &[]osdAdmin.Blocklist{
-					{
-						Addr:  "2001:db8::1:0/128",
-						Until: time.Now().Format(time.RFC3339),
-					},
-				},
-				addr: "2001:db8::1",
-			},
-			want:    false,
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/csi-addons/networkfence/fencing_test.go
+++ b/internal/csi-addons/networkfence/fencing_test.go
@@ -350,11 +350,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(1 * time.Hour),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(1 * time.Hour),
 					},
 				},
@@ -368,11 +368,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - blockListCoolDownPeriod),
 					},
 				},
@@ -386,11 +386,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime),
 					},
 				},
@@ -404,11 +404,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now().Add(util.AutoBlocklistTime - 2*time.Minute),
 					},
 				},
@@ -454,11 +454,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now(),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now(),
 					},
 				},
@@ -472,11 +472,11 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::3:0/128",
+						Addr:  "[2001:db8::3]:0/128",
 						Until: time.Now(),
 					},
 					{
-						Addr:  "2001:db8::2:0/128",
+						Addr:  "[2001:db8::2]:0/128",
 						Until: time.Now(),
 					},
 				},
@@ -490,7 +490,7 @@ func Test_containsMatchingBlockListEntry(t *testing.T) {
 			args: args{
 				blocklist: &[]osdAdmin.Blocklist{
 					{
-						Addr:  "2001:db8::1:0/128",
+						Addr:  "[2001:db8::1]:0/128",
 						Until: time.Now().Add(util.MaxBlocklistTime),
 					},
 				},
@@ -544,25 +544,25 @@ func Test_matchEntry(t *testing.T) {
 		},
 		{
 			name:     "IPv6 match with /128 suffix",
-			actual:   "2001:db8::1:0/128",
+			actual:   "[2001:db8::1]:0/128",
 			expected: "2001:db8::1",
 			want:     true,
 		},
 		{
 			name:     "IPv6 match without /128 suffix",
-			actual:   "2001:db8::1:0/123213",
+			actual:   "[2001:db8::1]:0/123213",
 			expected: "2001:db8::1",
 			want:     false,
 		},
 		{
 			name:     "IPv6 no match different IPs",
-			actual:   "2001:db8::2:0/128",
+			actual:   "[2001:db8::2]:0/128",
 			expected: "2001:db8::1",
 			want:     false,
 		},
 		{
 			name:     "IPv6 compressed notation match",
-			actual:   "fd4a:ecbc:cafd:4e49::1:0/128",
+			actual:   "[fd4a:ecbc:cafd:4e49::1]:0/128",
 			expected: "fd4a:ecbc:cafd:4e49::1",
 			want:     true,
 		},

--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"time"
@@ -355,14 +356,20 @@ func RemoveCephBlocklist(ctx context.Context, monitors string, cr *Credentials, 
 	}
 
 	var clientAddr string
+	//nolint:nestif // straightforward IPv4/IPv6 formatting with nonce
 	if useRange {
-		// When useRange is true, ip is already in CIDR format
 		clientAddr = ip
 	} else {
-		// If nonce is not empty and we are not using
-		// range based blocks, we need to add the nonce
 		if nonce != "" {
-			clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+			parsedIP := net.ParseIP(ip)
+			if parsedIP == nil {
+				return fmt.Errorf("failed to parse IP address %q", ip)
+			}
+			if parsedIP.To4() != nil {
+				clientAddr = fmt.Sprintf("%s:0/%s", ip, nonce)
+			} else {
+				clientAddr = fmt.Sprintf("[%s]:0/%s", ip, nonce)
+			}
 		} else {
 			clientAddr = ip
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,7 +209,7 @@ github.com/ceph/ceph-csi/api/deploy/ocp
 # github.com/ceph/ceph-nvmeof/lib/go/nvmeof v0.0.0-20251105130956-2cc225b176fc
 ## explicit; go 1.24.4
 github.com/ceph/ceph-nvmeof/lib/go/nvmeof
-# github.com/ceph/go-ceph v0.36.0 => github.com/red-hat-storage/go-ceph v0.32.1-0.20260109062642-357605f36918
+# github.com/ceph/go-ceph v0.36.0 => github.com/red-hat-storage/go-ceph v0.32.1-0.20260112083340-565356f9872c
 ## explicit; go 1.24.0
 github.com/ceph/go-ceph/cephfs
 github.com/ceph/go-ceph/cephfs/admin
@@ -1274,5 +1274,5 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 # github.com/ceph/ceph-csi/api => ./api
-# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20260109062642-357605f36918
+# github.com/ceph/go-ceph => github.com/red-hat-storage/go-ceph v0.32.1-0.20260112083340-565356f9872c
 # k8s.io/client-go => k8s.io/client-go v0.34.2


### PR DESCRIPTION
Ceph returns IPv6 blocklist entries in bracket format (e.g.
[fd98::9]:0/128), but matchEntry did not strip brackets after
removing the :0/128 suffix, causing net.ParseIP to fail and
auto-unfence to silently skip all IPv6 entries.

Similarly, RemoveCephBlocklist formatted IPv6 addresses without
brackets (fd98::9:0/0 instead of [fd98::9]:0/0), producing
malformed addresses rejected by Ceph.

Fix matchEntry to strip brackets for IPv6, fix RemoveCephBlocklist
to wrap IPv6 in brackets, and update test data to use real Ceph
bracket format.

Signed-off-by: Rakshith R <rar@redhat.com>
Co-authored-by: Praveen M <m.praveen@ibm.com>
(cherry picked from commit https://github.com/red-hat-storage/ceph-csi/commit/c925e81f87627f81ab483c98a9804f61ea05f5b9)
Signed-off-by: Praveen M <m.praveen@ibm.com>