### PR TITLE
[release-4.18] Bump golang.org/x/crypto from v0.36.0 to 0.52.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/pkg/xattr v0.4.10
 	github.com/prometheus/client_golang v1.20.5
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/crypto v0.36.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.37.0
 	golang.org/x/sys v0.31.0
 	google.golang.org/grpc v1.68.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -746,7 +746,7 @@ go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
 go.uber.org/zap/zapgrpc
-# golang.org/x/crypto v0.36.0 => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
+# golang.org/x/crypto v0.52.0 => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581
 ## explicit; go 1.20
 golang.org/x/crypto/argon2
 golang.org/x/crypto/blake2b


### PR DESCRIPTION
### Changes
- **golang.org/x/crypto**: `v0.36.0` → `0.52.0` (in `go.mod`)
