### PR TITLE
[release-4.19] Bump go (stdlib) from 1.23.0 to 1.23.1

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/api
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,7 +195,7 @@ github.com/blang/semver/v4
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
 # github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.23.0
+## explicit; go 1.23.1
 github.com/ceph/ceph-csi/api/deploy/kubernetes
 github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.23.0` → `1.23.1` (in `api/go.mod`)
