### PR TITLE
[release-4.22] Bump go (stdlib) from 1.25.0 to 1.25.5

### DIFF
--- a/actions/retest/go.mod
+++ b/actions/retest/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/actions/retest
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/google/go-github v17.0.0+incompatible

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/api
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/e2e
 
-go 1.25.0
+go 1.25.5
 
 // my own dependencies
 replace (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi
 
-go 1.25.0
+go 1.25.5
 
 // our own API
 replace github.com/ceph/ceph-csi/api => ./api

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/blang/semver/v4
 ## explicit; go 1.18
 github.com/cenkalti/backoff/v4
 # github.com/ceph/ceph-csi/api v0.0.0-00010101000000-000000000000 => ./api
-## explicit; go 1.25.0
+## explicit; go 1.25.5
 github.com/ceph/ceph-csi/api/deploy/kubernetes
 github.com/ceph/ceph-csi/api/deploy/kubernetes/cephfs
 github.com/ceph/ceph-csi/api/deploy/kubernetes/nfs


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.0` → `1.25.5` (in `e2e/go.mod`)
- **go (stdlib)**: `1.25.0` → `1.25.5` (in `go.mod`)
- **go (stdlib)**: `1.25.0` → `1.25.5` (in `actions/retest/go.mod`)
- **go (stdlib)**: `1.25.0` → `1.25.5` (in `api/go.mod`)
