### PR TITLE
DFBUGS-6930: [release-4.19] build: use Go 1.25.9

### DIFF
--- a/build.env
+++ b/build.env
@@ -26,7 +26,7 @@ BASE_IMAGE=quay.ceph.io/ceph-ci/ceph:wip-rbd-cgsm-base
 CEPH_VERSION=squid
 
 # standard Golang options
-GOLANG_VERSION=1.24.6
+GOLANG_VERSION=1.25.9
 GO111MODULE=on
 
 # commitlint version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi
 
-go 1.24.0
+go 1.25.0
 
 // our own API
 replace github.com/ceph/ceph-csi/api => ./api


### PR DESCRIPTION
Go 1.25.9 fixes CVE-2026-32281: a denial of service in crypto/x509 Certificate.Verify caused by inefficient validation of certificate chains containing a very large number of policy mappings.

Ref: https://pkg.go.dev/vuln/GO-2026-4946
