### PR TITLE
DFBUGS-6862: [release-4.21] build: update Go version to 1.25.9

### DIFF
--- a/actions/retest/go.mod
+++ b/actions/retest/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/actions/retest
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/google/go-github v17.0.0+incompatible

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,6 @@
 module github.com/ceph/ceph-csi/api
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.9
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/build.env
+++ b/build.env
@@ -26,7 +26,7 @@ BASE_IMAGE=quay.ceph.io/ceph-ci/ceph:wip-rbd-cgsm-base
 CEPH_VERSION=squid
 
 # standard Golang options
-GOLANG_VERSION=1.24.6
+GOLANG_VERSION=1.25.9
 GO111MODULE=on
 
 # commitlint version

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi/e2e
 
-go 1.24.6
+go 1.25.9
 
 // my own dependencies
 replace (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/ceph-csi
 
-go 1.24.6
+go 1.25.9
 
 // our own API
 replace github.com/ceph/ceph-csi/api => ./api


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://github.com/ceph/ceph-csi/blob/devel/docs/development-guide.md#Code-contribution-workflow)
documentation before submitting a Pull Request!
Thank you for contributing to ceph-csi! -->

Fixes: CVE-2026-25679
Fixes: CVE-2026-32280
Fixes: CVE-2026-32282
